### PR TITLE
Transition to using ContainerKojiBuild

### DIFF
--- a/src/app/pipes/nodedisplay.ts
+++ b/src/app/pipes/nodedisplay.ts
@@ -10,6 +10,7 @@ export class NodeUidDisplayPipe implements PipeTransform {
         case('distgitcommit'):
             return '#' + node.hash.slice(0, 7);
         case('kojibuild'):
+        case('containerkojibuild'):
             return `${node.name}-${node.version}-${node.release}`;
         case('advisory'):
             return node.advisory_name;
@@ -35,7 +36,7 @@ export class NodeTypeDisplayPipe implements PipeTransform {
             return 'Advisory';
         case('freshmakerevent'):
             return 'Freshmaker Event';
-        case('containerbuild'):
+        case('containerkojibuild'):
             return 'Container Build';
         default:
             return nodeType;
@@ -72,13 +73,12 @@ export class NodeExternalUrlPipe implements PipeTransform {
                 }
                 return baseUrl;
             case('kojibuild'):
+            case('containerkojibuild'):
                 return `https://brew.engineering.redhat.com/brew/buildinfo?buildID=${node.id}`;
             case('advisory'):
                 return `http://errata.engineering.redhat.com/advisory/${node.id}`;
             case('freshmakerevent'):
                 return `https://freshmaker.engineering.redhat.com/api/1/events/${node.id}`;
-            case('containerbuild'):
-                return `https://freshmaker.engineering.redhat.com/api/1/builds/${node.id}`;
             default:
                 return '';
         }

--- a/src/app/services/story.service.spec.ts
+++ b/src/app/services/story.service.spec.ts
@@ -80,7 +80,7 @@ describe('StoryService testing', () => {
           'related_nodes': {
             'Advisory': 0,
             'BugzillaBug': 3,
-            'ContainerBuild': 0,
+            'ContainerKojiBuild': 0,
             'DistGitCommit': 0,
             'FreshmakerEvent': 0,
             'KojiBuild': 0

--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -133,9 +133,9 @@ describe('StoryComponent testing', () => {
     // Ensure the number of columns in the row
     expect(storyRowEls[5].nativeElement.children.length).toBe(2);
     // Ensure the text is correct
-    expect(storyRowEls[5].nativeElement.firstElementChild.innerText).toBe('397');
+    expect(storyRowEls[5].nativeElement.firstElementChild.innerText).toBe('rh-perl520-docker-5.20-17.1525804575');
     // Ensure the order is correct
-    expect(storyRowEls[5].nativeElement.children[1].firstElementChild.id).toBe('ContainerBuildPrimary');
+    expect(storyRowEls[5].nativeElement.children[1].firstElementChild.id).toBe('ContainerKojiBuildPrimary');
     // Ensure the it is not active
     expect(storyRowEls[5].nativeElement.children[1].firstElementChild.classList).not.toContain('active');
   }));

--- a/src/app/story/storyrow/storyrow.component.ts
+++ b/src/app/story/storyrow/storyrow.component.ts
@@ -90,7 +90,7 @@ export class StoryRowComponent implements OnInit, AfterViewInit {
         return 'pficon-security';
       case('FreshmakerEvent'):
         return 'fa-refresh';
-      case('ContainerBuild'):
+      case('ContainerKojiBuild'):
         return 'pficon-build';
       default:
         return 'fa-cube';

--- a/src/app/story/test.data.ts
+++ b/src/app/story/test.data.ts
@@ -144,29 +144,24 @@ export let story = {
       'url': '/api/1/events/1180'
     },
     {
-      'build_id': 15639047,
-      'dep_on': null,
-      'event_id': 1180,
-      'id': '397',
-      'name': 'jboss-eap-7-eap70-openshift-docker',
-      'original_nvr': 'jboss-eap-7-eap70-openshift-docker-1.4-36',
-      'rebuilt_nvr': 'jboss-eap-7-eap70-openshift-docker-1.4-36.1522094763',
-      'resource_type': 'ContainerBuild',
+      'completion_time': '2018-05-08T19:17:42+00:00',
+      'creation_time': '2018-05-08T19:17:44.180482+00:00',
+      'epoch': null,
+      'id': '687618',
+      'name': 'rh-perl520-docker',
+      'original_nvr': null,
+      'release': '17.1525804575',
+      'resource_type': 'ContainerKojiBuild',
+      'start_time': '2018-05-08T18:56:25+00:00',
       'state': 1,
-      'state_name': 'DONE',
-      'state_reason': 'Built successfully.',
-      'time_completed': '2017-04-02T19:39:06+00:00',
-      'time_submitted': '2017-04-02T19:39:06+00:00',
-      'type': 1,
-      'type_name': 'IMAGE',
-      'url': '/api/1/builds/397'
+      'version': '5.20'
     }
   ],
   'meta': {
     'related_nodes': {
       'Advisory': 0,
       'BugzillaBug': 1,
-      'ContainerBuild': 0,
+      'ContainerKojiBuild': 0,
       'DistGitCommit': 0,
       'FreshmakerEvent': 0,
       'KojiBuild': 0


### PR DESCRIPTION
With the latest deployment of the API in prod, we must now treat containers builds as Koji builds.