### PR TITLE
Truncate the displayed UIDs to be 30 characters if they are too long

### DIFF
--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -133,7 +133,7 @@ describe('StoryComponent testing', () => {
     // Ensure the number of columns in the row
     expect(storyRowEls[5].nativeElement.children.length).toBe(2);
     // Ensure the text is correct
-    expect(storyRowEls[5].nativeElement.firstElementChild.innerText).toBe('rh-perl520-docker-5.20-17.1525804575');
+    expect(storyRowEls[5].nativeElement.firstElementChild.innerText).toBe('rh-perl520-docker-5.20-17.1525…');
     // Ensure the order is correct
     expect(storyRowEls[5].nativeElement.children[1].firstElementChild.id).toBe('ContainerKojiBuildPrimary');
     // Ensure the it is not active

--- a/src/app/story/storyrow/storyrow.component.html
+++ b/src/app/story/storyrow/storyrow.component.html
@@ -1,4 +1,4 @@
-<div class="mainItemText">{{ node | nodeUidDisplay }}</div>
+<div class="mainItemText">{{ node | nodeUidDisplay | truncate: 30 }}</div>
 <div class="mainItem">
   <div [appPlumbConnect]="prevNodeIDs" id="{{ node.resource_type + 'Primary' }}"
       [ngClass]="{'active': active}" [routerLink]="['/', node.resource_type.toLowerCase(), getNodeUid()]"

--- a/src/app/story/storyrow/storyrow.component.spec.ts
+++ b/src/app/story/storyrow/storyrow.component.spec.ts
@@ -6,7 +6,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { StoryRowComponent, PlumbConnectDirective } from './storyrow.component';
 import { bug } from '../test.data';
-import { NodeUidDisplayPipe, NodeTypeDisplayPipe, NodeTypePluralPipe } from '../../pipes/nodedisplay';
+import { NodeUidDisplayPipe, NodeTypeDisplayPipe, NodeTypePluralPipe, TruncatePipe } from '../../pipes/nodedisplay';
 
 
 describe('StoryRowComponent testing', () => {
@@ -20,7 +20,8 @@ describe('StoryRowComponent testing', () => {
             PlumbConnectDirective,
             NodeUidDisplayPipe,
             NodeTypeDisplayPipe,
-            NodeTypePluralPipe
+            NodeTypePluralPipe,
+            TruncatePipe
         ],
         imports: [RouterTestingModule, TooltipModule.forRoot()]
     }).compileComponents();

--- a/src/app/story/storysidebar/story.sidebar.component.spec.ts
+++ b/src/app/story/storysidebar/story.sidebar.component.spec.ts
@@ -6,6 +6,7 @@ import { StorysidebarComponent } from './storysidebar.component';
 import { NodeUidDisplayPipe, NodeExternalUrlPipe, TruncatePipe } from '../../pipes/nodedisplay';
 import { PropertyDisplayPipe } from '../../pipes/propertydisplay';
 import { bug } from '../test.data';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 
 describe('StorysidebarComponent testing', () => {
@@ -23,6 +24,9 @@ describe('StorysidebarComponent testing', () => {
         ],
         providers: [
           DatePipe
+        ],
+        imports: [
+          TooltipModule.forRoot()
         ]
     }).compileComponents();
   });

--- a/src/app/story/storysidebar/storysidebar.component.html
+++ b/src/app/story/storysidebar/storysidebar.component.html
@@ -9,7 +9,13 @@
   </div>
   <ng-container *ngIf="sidebarOpen && node">
     <a [href]="node | nodeExternalUrl" target="_blank">
-      <h2>{{ node | nodeUidDisplay }}</h2>
+      <!-- *ngIf is used because it should only tooltip on long UIDs -->
+      <h2 *ngIf="(node | nodeUidDisplay).length > 30; else shortUid" tooltip="{{ node | nodeUidDisplay }}">
+        {{ node | nodeUidDisplay | truncate: 30 }}
+      </h2>
+      <ng-template #shortUid>
+        <h2>{{ node | nodeUidDisplay }}</h2>
+      </ng-template>
     </a>
     <table id="sidebarProperties">
       <tbody>


### PR DESCRIPTION
For example, this would change "cfme-httpd-configmap-generator-container-0.2.1-22.1527091929" to "cfme-httpd-configmap-generator…". The user can then hover over the shape to get the full UID