### PR TITLE
Fix the connection directions with siblings in the story flow

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,7 +10,7 @@ import { NotificationModule } from 'patternfly-ng/notification';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { StoryComponent } from './story/story.component';
-import { StoryRowComponent, PlumbConnectDirective } from './story/storyrow/storyrow.component';
+import { StoryRowComponent } from './story/storyrow/storyrow.component';
 import { StorysidebarComponent } from './story/storysidebar/storysidebar.component';
 import { PropertyDisplayPipe } from './pipes/propertydisplay';
 import { NodeUidDisplayPipe, NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe,
@@ -27,7 +27,6 @@ import { NavbarComponent } from './navbar/navbar.component';
     StoryComponent,
     StoryRowComponent,
     StorysidebarComponent,
-    PlumbConnectDirective,
     PropertyDisplayPipe,
     NodeUidDisplayPipe,
     SearchComponent,

--- a/src/app/story/story.component.html
+++ b/src/app/story/story.component.html
@@ -2,10 +2,12 @@
 <app-navbar></app-navbar>
 
 <div class="container-fluid">
-  <div id="diagram" *ngIf="story">
-    <app-storyrow id="{{ 'storyRow' + i }}" [node]="node" [relatedNodes]="story.meta.story_related_nodes[i]"
-        [active]="node === selectedNode" *ngFor="let node of story.data; let i = index">
-    </app-storyrow>
+  <div id="diagram">
+    <ng-container *ngIf="story">
+      <app-storyrow [node]="node" [relatedNodes]="story.meta.story_related_nodes[i]" [last]="last"
+          [active]="node === selectedNode" *ngFor="let node of story.data; let i = index; let last = last">
+      </app-storyrow>
+    </ng-container>
   </div>
 </div>
 

--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -11,7 +11,7 @@ import { of, Subject } from 'rxjs';
 
 import { StoryComponent } from './story.component';
 import { StorysidebarComponent } from './storysidebar/storysidebar.component';
-import { StoryRowComponent, PlumbConnectDirective } from './storyrow/storyrow.component';
+import { StoryRowComponent } from './storyrow/storyrow.component';
 import { AlertComponent } from '../alert/alert.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { NavbarComponent } from '../navbar/navbar.component';
@@ -34,7 +34,6 @@ describe('StoryComponent testing', () => {
             StoryComponent,
             StoryRowComponent,
             StorysidebarComponent,
-            PlumbConnectDirective,
             NodeUidDisplayPipe,
             NodeTypeDisplayPipe,
             NodeTypePluralPipe,

--- a/src/app/story/storyrow/storyrow.component.html
+++ b/src/app/story/storyrow/storyrow.component.html
@@ -1,6 +1,6 @@
 <div class="mainItemText">{{ node | nodeUidDisplay | truncate: 30 }}</div>
 <div class="mainItem">
-  <div [appPlumbConnect]="prevNodeIDs" id="{{ node.resource_type + 'Primary' }}"
+  <div id="{{ node.resource_type + 'Primary' }}"
       [ngClass]="{'active': active}" [routerLink]="['/', node.resource_type.toLowerCase(), getNodeUid()]"
       tooltip="{{ node.resource_type | nodeTypeDisplay }}: {{ node | nodeUidDisplay }}">
     <img src="assets/circle_single.svg" />
@@ -8,7 +8,7 @@
   </div>
 </div>
 <div *ngIf="relatedNodes" class="secondaryItem">
-  <div [appPlumbConnect]="prevNodeIDs" id="{{ node.resource_type + 'Secondary'}}"
+  <div id="{{ node.resource_type + 'Secondary'}}"
       tooltip="Related {{ node.resource_type | nodeTypeDisplay | nodeTypePlural }}">
     <img src="assets/circle_multi.svg" />
     <div class="secondaryItemIconContainer"><i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i></div>

--- a/src/app/story/storyrow/storyrow.component.spec.ts
+++ b/src/app/story/storyrow/storyrow.component.spec.ts
@@ -4,9 +4,10 @@ import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core
 import { RouterTestingModule } from '@angular/router/testing';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
-import { StoryRowComponent, PlumbConnectDirective } from './storyrow.component';
+import { StoryRowComponent } from './storyrow.component';
 import { bug } from '../test.data';
 import { NodeUidDisplayPipe, NodeTypeDisplayPipe, NodeTypePluralPipe, TruncatePipe } from '../../pipes/nodedisplay';
+import { StoryComponent } from '../story.component';
 
 
 describe('StoryRowComponent testing', () => {
@@ -17,11 +18,13 @@ describe('StoryRowComponent testing', () => {
     TestBed.configureTestingModule({
         declarations: [
             StoryRowComponent,
-            PlumbConnectDirective,
             NodeUidDisplayPipe,
             NodeTypeDisplayPipe,
             NodeTypePluralPipe,
             TruncatePipe
+        ],
+        providers: [
+          {provide: StoryComponent, useValue: {connectStory: () => {}}}
         ],
         imports: [RouterTestingModule, TooltipModule.forRoot()]
     }).compileComponents();
@@ -70,5 +73,16 @@ describe('StoryRowComponent testing', () => {
 
     const secondaryItemTextEl = fixture.debugElement.query(By.css('.secondaryItemText')).nativeElement;
     expect(secondaryItemTextEl.innerText).toBe('5 more');
+  }));
+
+  it('should call story.connectStory when it\'s the last row', fakeAsync(() => {
+    component.node = bug;
+    component.relatedNodes = 0;
+    component.active = true;
+    component.last = true;
+    spyOn(component.story, 'connectStory').and.returnValue(null);
+    fixture.detectChanges();
+    tick();
+    expect(component.story.connectStory).toHaveBeenCalled();
   }));
 });


### PR DESCRIPTION
Previously, the nodes were connected to their previous node all the time which is incorrect. That should only be done on the last node in the story. Because the connections must go forward, the code to do the connection had to moved up to StoryComponent, since at execution time, the StoryRowComponents would not have access to the next row since it doesn't exist yet.