### PR TITLE
Conform to BEM styling

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -1,10 +1,27 @@
-/* A hack that fixes an overflowing page in mobile view */
-.container-fluid > .navbar-header {
+/* ----- Elements ----- */
+.navbar-left__brand {
+    color: #282d33;
+    background-color: #efefef;
+    margin-left: 1rem;
+    padding: 1.5px 10px 1.5px 10px;
+}
+
+.navbar-right__brand {
+    height: 30px;
+    margin-top: 10px;
+    /* Don't show the right logo in mobile view */
+    display: none;
+}
+
+
+/* ----- Bootstrap Overrides ----- */
+.navbar-header {
+    /* A hack that fixes an overflowing page in mobile view */
     margin-left: 0 !important;
     margin-right: 0 !important;
 }
 
-nav.navbar {
+.navbar {
     background-color: #282d33;
 }
 
@@ -14,36 +31,19 @@ nav.navbar {
     font-size: 1.5rem;
 }
 
-#brandPipeline {
-    color: #282d33;
-    background-color: #efefef;
-    margin-left: 1rem;
-    padding: 1.5px 10px 1.5px 10px;
-}
-
-.navbar-right {
-    /* Don't show the right logo in mobile view */
-    display: none;
-}
-
-#brandRightLogo {
-    height: 30px;
-    margin-top: 10px;
-}
-
 @media (min-width: 768px) {
-    .navbar-right {
+    .navbar-right__brand {
         display: initial;
     }
 
-    nav > div.container-fluid {
+    .navbar__container {
         padding-left: 5rem;
         padding-right: 5rem;
     }
 }
 
 @media (min-width: 992px) {
-    nav > div.container-fluid {
+    .navbar__container {
         padding-left: 7.5rem;
         padding-right: 7.5rem;
     }

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,10 +1,10 @@
 <nav class="navbar">
-  <div class="container-fluid">
+  <div class="container-fluid navbar__container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="#">RED HAT <span id="brandPipeline">PIPELINE</span></a>
+      <a class="navbar-brand" href="#">RED HAT <span class="navbar-left__brand">PIPELINE</span></a>
     </div>
     <div class="navbar-header navbar-right">
-      <img id="brandRightLogo" src="assets/redhat_logo.png" />
+      <img class="navbar-right__brand" src="assets/redhat_logo.png" />
     </div>
   </div>
 </nav>

--- a/src/app/search/search.component.css
+++ b/src/app/search/search.component.css
@@ -1,58 +1,19 @@
-/* Create the left sidebar */
-#searchContainer {
+/* ----- Blocks ----- */
+.search {
     /* Take up the whole screen in portrait mobile mode */
     width: 100%;
     min-height: 100vh;
     background-color: #000000;
     padding-top: 4rem;
     padding-bottom: 4rem;
-}
-
-#searchContainer > * {
-    margin-left: 2.5rem;
-}
-
-#searchContainer {
     color: #efefef;
 }
 
-#logoText > h3 {
-    font-size: 150%;
-    font-weight: 600;
-    margin-bottom: 5rem;
-}
-
-#logoSubText {
-    margin-left: 1rem;
-    padding: 1.5px 10px 1.5px 10px;
-    color: #000000;
-    background-color: #efefef;
-}
-
-#title, #subtitle {
-    font-size: 230%;
-    font-weight: 600;
-}
-
-#title {
-    margin-bottom: 0.5rem;
-}
-
-#subtitle {
-    margin-top: 0;
-}
-
-#helpText {
-    font-size: 130%;
-    margin-top: 2.5rem;
-    color: #efefef;
-}
-
-#searchForm {
+.search-form {
     margin-top: 5rem;
 }
 
-#searchForm > select, #searchForm > input {
+.search-select, .search-input {
     /* Stack the form elements in mobile view */
     display: block;
     /* Make the form elements have the same width when stacked in mobile view */
@@ -66,7 +27,7 @@
     border: 0.25px solid #777777;
 }
 
-#searchForm > select {
+.search-select {
     padding-left: 7.5px;
     margin-right: 1rem;
     /* Workaround to replace the ugly arrow in Firefox */
@@ -79,62 +40,30 @@
     padding-right: 25px;
 }
 
-#searchForm > select > option {
-    background-color: #F8F8F8;
-    color: #363636;
-}
-
-#searchForm > input {
-    padding-left: 0.75rem;
-    /* Animate the highlight effect */
-    transition: all 0.30s ease-in-out;
-}
-
-#searchForm > input:focus {
-    /* Highlight the input border when the user clicks on it */
-    box-shadow: 0 0 5px #00659c;
-    border: 0.25px solid #00659c;
-}
-
-#searchForm > button {
-    display: block;
-    /* Don't show an outline on the element when it is focused */
-    outline: 0;
-    font-size: 120%;
-    margin-top: 3rem;
-    /* Make the button bigger and curved */
-    border-radius: 2rem;
-    padding: 2.5px 22px 2.5px 22px;
-}
-
-#redHatLogo {
+.watermark {
     /* Don't display the Red Hat logo in mobile view since there isn't enough room */
     display: none;
 }
 
 @media (min-width: 600px) {
     /* Only take up half the screen once we know the sidebar would be at least 300px */
-    #searchContainer {
+    .search {
         width: 50%;
     }
 }
 
 @media (min-width: 992px) {
-    #searchContainer > * {
+    .search > * {
         margin-left: 5rem;
     }
 
-    #logoText > h3 {
-        margin-bottom: 8rem;
-    }
-
-    #searchForm > select, #searchForm > input {
+    .search-select, .search-input {
         display: inline-block;
         width: auto;
     }
 
     /* Display the Red Hat logo in the top right corner */
-    #redHatLogo {
+    .watermark {
         display: initial;
         position: absolute;
         right: 5rem;
@@ -144,9 +73,84 @@
 }
 
 @media (min-width: 1200px) {
-    #searchContainer {
+    .search {
         /* Using static value here instead of max-width for easier calculations
         with the background image offset */
         width: 600px;
     }
+}
+
+/* ----- Elements ----- */
+
+.search > * {
+    margin-left: 2.5rem;
+}
+
+.brand__text {
+    font-size: 150%;
+    font-weight: 600;
+    margin-bottom: 5rem;
+}
+
+.search__title, .search__subtitle {
+    font-size: 230%;
+    font-weight: 600;
+}
+
+.search__title {
+    margin-bottom: 0.5rem;
+}
+
+.search__subtitle {
+    margin-top: 0;
+}
+
+.search__explanation {
+    font-size: 130%;
+    margin-top: 2.5rem;
+    color: #efefef;
+}
+
+.search-option {
+    background-color: #F8F8F8;
+    color: #363636;
+}
+
+.search-input {
+    padding-left: 0.75rem;
+    /* Animate the highlight effect */
+    transition: all 0.30s ease-in-out;
+}
+
+.search-input:focus {
+    /* Highlight the input border when the user clicks on it */
+    box-shadow: 0 0 5px #00659c;
+    border: 0.25px solid #00659c;
+}
+
+@media (min-width: 992px) {
+    .brand__text {
+        margin-bottom: 8rem;
+    }
+}
+
+
+/* ----- Modifiers ----- */
+
+.brand__text--highlight {
+    margin-left: 1rem;
+    padding: 1.5px 10px 1.5px 10px;
+    color: #000000;
+    background-color: #efefef;
+}
+
+.btn--lg-rounded {
+    display: block;
+    /* Don't show an outline on the element when it is focused */
+    outline: 0;
+    font-size: 120%;
+    margin-top: 3rem;
+    /* Make the button bigger and curved */
+    border-radius: 2rem;
+    padding: 2.5px 22px 2.5px 22px;
 }

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -1,25 +1,29 @@
-<div id="searchContainer">
-  <div id="logoText">
-    <h3>RED HAT <span id="logoSubText">PIPELINE</span></h3>
+<div class="search">
+  <div>
+    <h3 class="brand__text">RED HAT <span class="brand__text--highlight">PIPELINE</span></h3>
   </div>
-  <h1 id="title">Red Hat Release Pipeline</h1>
-  <h1 id="subtitle">Visualization Tool</h1>
 
-  <h3 id="helpText">Select an artifact to get started.</h3>
-  <div id="searchForm" *ngIf="availableResources">
-    <select [(ngModel)]="selectedResource" id="resourceSelector">
-      <option *ngFor="let resource of availableResources" [value]="resource.name">
+  <h1 class="search__title">Red Hat Release Pipeline</h1>
+  <h1 class="search__subtitle">Visualization Tool</h1>
+
+  <h3 class="search__explanation">Select an artifact to get started.</h3>
+
+  <div class="search-form" *ngIf="availableResources">
+    <select [(ngModel)]="selectedResource" class="search-select">
+      <option *ngFor="let resource of availableResources" [value]="resource.name" class="search-option">
         {{ resource.displayName }}
       </option>
     </select>
-    <input (keyup.enter)="navigateToStory()" [(ngModel)]="selectedUID" type="text" required
+
+    <input (keyup.enter)="navigateToStory()" [(ngModel)]="selectedUID" class="search-input" type="text" required
         placeholder="Enter an identifier">
-    <button (click)="navigateToStory()" id="searchButton" class="btn btn-info" type="button">
+
+    <button (click)="navigateToStory()" id="searchButton" class="btn btn-info btn--lg-rounded" type="button">
       Show Story
     </button>
   </div>
 </div>
 
-<img id="redHatLogo" src="assets/redhat_logo.png" />
+<img class="watermark" src="assets/redhat_logo.png" />
 
 <app-alert [(errorMsg)]="errorMsg"></app-alert>

--- a/src/app/spinner/spinner.component.css
+++ b/src/app/spinner/spinner.component.css
@@ -1,4 +1,5 @@
-#overlayContainer {
+/* ----- Blocks ----- */
+.overlay-container {
     position: absolute;
     top: 52px;
     background-color: #C0C0C0;
@@ -7,7 +8,9 @@
     z-index: 100;
 }
 
-#spinner {
+
+/* ----- Elements ----- */
+.overlay-container__spinner {
   position: fixed;
   top: 70px;
   left: calc(50% - 5.5px);
@@ -16,14 +19,14 @@
 }
 
 /* CSS taken from https://projects.lukehaas.me/css-loaders/ with slight modifications */
-#spinner, #spinner:before, #spinner:after {
+.overlay-container__spinner, .overlay-container__spinner:before, .overlay-container__spinner:after {
   background: #FFFFFF;
   animation: load1 1s infinite ease-in-out;
   width: 1rem;
   height: 4rem;
 }
 
-#spinner {
+.overlay-container__spinner {
   color: #FFFFFF;
   text-indent: -9999rem;
   font-size: 11px;
@@ -31,18 +34,18 @@
   animation-delay: -0.16s;
 }
 
-#spinner:before, #spinner:after {
+.overlay-container__spinner:before, .overlay-container__spinner:after {
   position: absolute;
   top: 0;
   content: '';
 }
 
-#spinner:before {
+.overlay-container__spinner:before {
   left: -1.5rem;
   animation-delay: -0.32s;
 }
 
-#spinner:after {
+.overlay-container__spinner:after {
   left: 1.5rem;
 }
 

--- a/src/app/spinner/spinner.component.html
+++ b/src/app/spinner/spinner.component.html
@@ -1,3 +1,3 @@
-<div id="overlayContainer" *ngIf="loading" @easeOut>
-  <div id="spinner"></div>
+<div class="overlay-container" *ngIf="loading" @easeOut>
+  <div class="overlay-container__spinner"></div>
 </div>

--- a/src/app/spinner/spinner.component.spec.ts
+++ b/src/app/spinner/spinner.component.spec.ts
@@ -25,17 +25,17 @@ describe('SpinnerComponent testing', () => {
     component.loading = true;
     fixture.detectChanges();
     expect(component.loading).toBe(true);
-    const overlayEl = fixture.debugElement.query(By.css('#overlayContainer')).nativeElement;
+    const overlayEl = fixture.debugElement.query(By.css('.overlay-container')).nativeElement;
     expect(overlayEl).toBeTruthy();
-    const spinnerEl = fixture.debugElement.query(By.css('#spinner')).nativeElement;
+    const spinnerEl = fixture.debugElement.query(By.css('.overlay-container__spinner')).nativeElement;
     expect(spinnerEl).toBeTruthy();
   });
 
   it('should not be visible when loading is false (default)', () => {
     expect(component.loading).toBe(false);
-    const overlay = fixture.debugElement.query(By.css('#overlayContainer'));
+    const overlay = fixture.debugElement.query(By.css('.overlay-container'));
     expect(overlay).toBeNull();
-    const spinner = fixture.debugElement.query(By.css('#spinner'));
+    const spinner = fixture.debugElement.query(By.css('.overlay-container__spinner'));
     expect(spinner).toBeNull();
   });
 });

--- a/src/app/story/story.component.css
+++ b/src/app/story/story.component.css
@@ -1,10 +1,11 @@
-#diagram {
+/* ----- Blocks ----- */
+.diagram {
     display: table;
     margin-bottom: 5rem;
 }
 
 @media (min-width: 992px) {
-    #diagram {
+    .diagram {
         margin: 2rem 0 0 3rem;
     }
 }

--- a/src/app/story/story.component.html
+++ b/src/app/story/story.component.html
@@ -2,7 +2,7 @@
 <app-navbar></app-navbar>
 
 <div class="container-fluid">
-  <div id="diagram">
+  <div class="diagram" id="js-diagram">
     <ng-container *ngIf="story">
       <app-storyrow [node]="node" [relatedNodes]="story.meta.story_related_nodes[i]" [last]="last"
           [active]="node === selectedNode" *ngFor="let node of story.data; let i = index; let last = last">

--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -85,11 +85,11 @@ describe('StoryComponent testing', () => {
     // Ensure the text is correct
     expect(storyRowEls[0].nativeElement.firstElementChild.innerText).toBe('RHBZ#12345');
     // Ensure the order is correct
-    expect(storyRowEls[0].nativeElement.children[1].firstElementChild.id).toBe('BugzillaBugPrimary');
+    expect(storyRowEls[0].nativeElement.children[1].firstElementChild.id).toBe('js-bugzillabug-node');
     // Ensure the Bugzilla Bug is the active one
-    expect(storyRowEls[0].nativeElement.children[1].firstElementChild.classList).toContain('active');
+    expect(storyRowEls[0].nativeElement.children[1].firstElementChild.classList).toContain('node-column__node--active');
     // Ensure a secondary Bugzilla Bug is shown
-    expect(storyRowEls[0].nativeElement.children[2].firstElementChild.id).toBe('BugzillaBugSecondary');
+    expect(storyRowEls[0].nativeElement.children[2].firstElementChild.id).toBe('js-bugzillabug-siblings');
     // Ensure the secondary Bugzilla Bug text is shown
     expect(storyRowEls[0].nativeElement.children[3].innerText).toBe('1 more');
 
@@ -98,44 +98,44 @@ describe('StoryComponent testing', () => {
     // Ensure the text is correct
     expect(storyRowEls[1].nativeElement.firstElementChild.innerText).toBe('#8a63adb');
     // Ensure the order is correct
-    expect(storyRowEls[1].nativeElement.children[1].firstElementChild.id).toBe('DistGitCommitPrimary');
+    expect(storyRowEls[1].nativeElement.children[1].firstElementChild.id).toBe('js-distgitcommit-node');
     // Ensure the it is not active
-    expect(storyRowEls[1].nativeElement.children[1].firstElementChild.classList).not.toContain('active');
+    expect(storyRowEls[1].nativeElement.children[1].firstElementChild.classList).not.toContain('node-column__node--active');
 
     // Ensure the number of columns in the row
     expect(storyRowEls[2].nativeElement.children.length).toBe(2);
     // Ensure the text is correct
     expect(storyRowEls[2].nativeElement.firstElementChild.innerText).toBe('slf4j-1.7.4-4.el7_4');
     // Ensure the order is correct
-    expect(storyRowEls[2].nativeElement.children[1].firstElementChild.id).toBe('KojiBuildPrimary');
+    expect(storyRowEls[2].nativeElement.children[1].firstElementChild.id).toBe('js-kojibuild-node');
     // Ensure the it is not active
-    expect(storyRowEls[2].nativeElement.children[1].firstElementChild.classList).not.toContain('active');
+    expect(storyRowEls[2].nativeElement.children[1].firstElementChild.classList).not.toContain('node-column__node--active');
 
     // Ensure the number of columns in the row
     expect(storyRowEls[3].nativeElement.children.length).toBe(2);
     // Ensure the text is correct
     expect(storyRowEls[3].nativeElement.firstElementChild.innerText).toBe('RHBA-2017:2251-02');
     // Ensure the order is correct
-    expect(storyRowEls[3].nativeElement.children[1].firstElementChild.id).toBe('AdvisoryPrimary');
+    expect(storyRowEls[3].nativeElement.children[1].firstElementChild.id).toBe('js-advisory-node');
     // Ensure the it is not active
-    expect(storyRowEls[3].nativeElement.children[1].firstElementChild.classList).not.toContain('active');
+    expect(storyRowEls[3].nativeElement.children[1].firstElementChild.classList).not.toContain('node-column__node--active');
 
     // Ensure the number of columns in the row
     expect(storyRowEls[4].nativeElement.children.length).toBe(2);
     // Ensure the text is correct
     expect(storyRowEls[4].nativeElement.firstElementChild.innerText).toBe('1180');
     // Ensure the order is correct
-    expect(storyRowEls[4].nativeElement.children[1].firstElementChild.id).toBe('FreshmakerEventPrimary');
+    expect(storyRowEls[4].nativeElement.children[1].firstElementChild.id).toBe('js-freshmakerevent-node');
     // Ensure the it is not active
-    expect(storyRowEls[4].nativeElement.children[1].firstElementChild.classList).not.toContain('active');
+    expect(storyRowEls[4].nativeElement.children[1].firstElementChild.classList).not.toContain('node-column__node--active');
 
     // Ensure the number of columns in the row
     expect(storyRowEls[5].nativeElement.children.length).toBe(2);
     // Ensure the text is correct
     expect(storyRowEls[5].nativeElement.firstElementChild.innerText).toBe('rh-perl520-docker-5.20-17.1525…');
     // Ensure the order is correct
-    expect(storyRowEls[5].nativeElement.children[1].firstElementChild.id).toBe('ContainerKojiBuildPrimary');
+    expect(storyRowEls[5].nativeElement.children[1].firstElementChild.id).toBe('js-containerkojibuild-node');
     // Ensure the it is not active
-    expect(storyRowEls[5].nativeElement.children[1].firstElementChild.classList).not.toContain('active');
+    expect(storyRowEls[5].nativeElement.children[1].firstElementChild.classList).not.toContain('node-column__node--active');
   }));
 });

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -89,13 +89,13 @@ export class StoryComponent implements OnInit, AfterViewInit, OnDestroy {
     // relationship flows backwards and is set after the loop
     for (let i = 0; i < storyRows.length - 1; i++) {
       // Connect the main node to the next main node
-      const target = storyRows[i + 1].querySelector('.mainItem').children[0];
+      const target = storyRows[i + 1].querySelector('.node-column').children[0];
       jsPlumb.connect({
-        source: storyRows[i].querySelector('.mainItem').children[0],
+        source: storyRows[i].querySelector('.node-column').children[0],
         target: target
       });
       // Check to see if this story row has siblings
-      const secondaryItem = storyRows[i].querySelector('.secondaryItem');
+      const secondaryItem = storyRows[i].querySelector('.node-siblings-column');
       if (secondaryItem) {
         // If there are siblings, connect them to the next main node
         jsPlumb.connect({
@@ -106,12 +106,12 @@ export class StoryComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     // Check to see if the last row has any siblings
-    const lastSecondaryItem = storyRows[storyRows.length - 1].querySelector('.secondaryItem');
-    if (lastSecondaryItem) {
+    const lastSiblingsItem = storyRows[storyRows.length - 1].querySelector('.node-siblings-column');
+    if (lastSiblingsItem) {
       // If there are siblings, connect them to the previous main node
       jsPlumb.connect({
-        source: lastSecondaryItem.children[0],
-        target: storyRows[storyRows.length - 2].querySelector('.mainItem').children[0],
+        source: lastSiblingsItem.children[0],
+        target: storyRows[storyRows.length - 2].querySelector('.node-column').children[0],
       });
     }
 

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -40,7 +40,7 @@ export class StoryComponent implements OnInit, AfterViewInit, OnDestroy {
   ngAfterViewInit() {
     // Set the defaults to jsPlumb after the view is initialized since jsPlumb will now be defined
     jsPlumb.importDefaults({
-      Container: 'diagram',
+      Container: 'js-diagram',
       Endpoint : 'Blank',
       Connector : ['Flowchart', {cornerRadius: 3}],
       Anchor: ['Bottom', 'Top'],

--- a/src/app/story/storyrow/storyrow.component.css
+++ b/src/app/story/storyrow/storyrow.component.css
@@ -1,42 +1,54 @@
+/* ----- Blocks ----- */
 :host {
     display: table-row;
     color: #6A6C6F;
 }
 
-:host > div {
+.story-row-column {
     display: table-cell;
     /* Leave a large vertical gap between nodes */
     padding-bottom: 6rem;
 }
 
-div.mainItemText {
+.node-uid-column {
     word-wrap: break-word;
     text-align: right;
     /* Leave a gap next to the main node */
     padding-right: 1.5rem;
 }
 
-div.mainItem {
+.node-uid-column, .node-siblings-text-column {
+    position: relative;
+    /* Vertically center the text */
+    top: 5px;
+}
+
+.node-column {
     /* Leave a decent gap between the main node and the siblings */
     padding-right: 5rem;
 }
 
-div.mainItem > div:hover {
-    /* Make the mouse look like a pointer so the user intuitively knows they can click on the shape */
-    cursor: pointer;
-    outline: 0;
-    /* Add a thin border when hovering over the node */
-    border: 3px solid #0088cc;
-    /* Hides the shadow effect of node's SVG while it is being bordered */
-    background-color: #FFFFFF;
+.node-siblings-text-column {
+    /* Don't show the "x more" text on mobile */
+    display: none;
 }
 
-div.mainItem > div:active img, div.mainItem > div:hover img {
-    /* Hides the shadow effect of node's SVG while it is being bordered */
-    opacity: 0;
+/* Roughly a small phone in landscape mode */
+@media (min-width : 550px) {
+    .node-siblings-text-column {
+        /* Display the "x more" text */
+        display: block;
+    }
+
+    .node-siblings-column {
+        /* Leave a small gap between the siblings and the "x more" text  */
+        padding-right: 1.25rem;
+    }
 }
 
-div.mainItem > div {
+
+/* ----- Elements ----- */
+.node-column__node {
     width: 68px;
     height: 66px;
     text-align: center;
@@ -46,7 +58,58 @@ div.mainItem > div {
     margin-left: 2px;
 }
 
-div.mainItem > div.active {
+.node-column__node, .node-column__siblings {
+    /* Make the position relative so that the icons can be absolutely positioned within it */
+    position: relative;
+}
+
+.node-column__node:hover {
+    /* Make the mouse look like a pointer so the user intuitively knows they can click on the shape */
+    cursor: pointer;
+    outline: 0;
+    /* Add a thin border when hovering over the node */
+    border: 3px solid #0088cc;
+    /* Hides the shadow effect of node's SVG while it is being bordered */
+    background-color: #FFFFFF;
+}
+
+.node-column__node:hover .node-column__node-img {
+    /* Hides the shadow effect of node's img while it is being bordered */
+    opacity: 0;
+}
+
+.node-column__node-img, .node-column__siblings-img {
+    /* Make the images take up the whole div that has a fixed size */
+    height: 100%;
+}
+
+.node-column__node-icon {
+    /* Place the icon halfway to the left of the circle */
+    left: 50%;
+}
+
+.node-column__node-icon, .node-siblings-column__node-icon {
+    /* Make the icons larger */
+    font-size: 2.25rem;
+    position: absolute;
+    /* Place the icon halfway down the circle */
+    top: 50%;
+    /* Move the icon half its size up and to the left */
+    transform: translate(-50%, -50%);
+}
+
+.node-siblings-column__node-icon {
+    /* Place the icon roughly a third to the left of the circle */
+    left: 36.6%;
+}
+
+.node-column__siblings {
+    width: 96px;
+    height: 66px;
+}
+
+/* ----- Modifiers ----- */
+.node-column__node--active, .node-column__node--active:hover  {
     /* Add a blue border on the node that the user queried for */
     border: 5px solid #0088cc;
     /* Also make the text blue */
@@ -60,61 +123,7 @@ div.mainItem > div.active {
     background-color: #FFFFFF;
 }
 
-div.secondaryItemText {
-    /* Don't show the "x more" text on mobile */
-    display: none;
-}
-
-div.mainItemText, div.secondaryItemText {
-    position: relative;
-    /* Vertically center the text */
-    top: 5px;
-}
-
-div.mainItem > div, div.secondaryItem > div {
-    /* Make the position relative so that the icons can be absolutely positioned within it */
-    position: relative;
-}
-
-div.mainItem > div > img, div.secondaryItem > div > img {
-    /* Make the images take up the whole div that has a fixed size */
-    height: 100%;
-}
-
-div.mainItemIconContainer, div.secondaryItemIconContainer {
-    /* Make the icons larger */
-    font-size: 2.25rem;
-    position: absolute;
-    /* Place the icon halfway down the circle */
-    top: 50%;
-    /* Move the icon half its size up and to the left */
-    transform: translate(-50%, -50%);
-}
-
-div.mainItemIconContainer {
-    /* Place the icon halfway to the left of the circle */
-    left: 50%;
-}
-
-div.secondaryItemIconContainer {
-    /* Place the icon roughly a third to the left of the circle */
-    left: 36.6%;
-}
-
-div.secondaryItem > div {
-    width: 96px;
-    height: 66px;
-}
-
-/* Roughly a small phone in landscape mode */
-@media (min-width : 550px) {
-    div.secondaryItemText {
-        /* Display the "x more" text */
-        display: block;
-    }
-
-    div.secondaryItem {
-        /* Leave a small gap between the siblings and the "x more" text  */
-        padding-right: 1.25rem;
-    }
+.node-column__node--active .node-column__node-img {
+    /* Hides the shadow effect of node's img while it is being bordered */
+    opacity: 0;
 }

--- a/src/app/story/storyrow/storyrow.component.html
+++ b/src/app/story/storyrow/storyrow.component.html
@@ -1,17 +1,16 @@
-<div class="mainItemText">{{ node | nodeUidDisplay | truncate: 30 }}</div>
-<div class="mainItem">
-  <div id="{{ node.resource_type + 'Primary' }}"
-      [ngClass]="{'active': active}" [routerLink]="['/', node.resource_type.toLowerCase(), getNodeUid()]"
+<div class="node-uid-column story-row-column">{{ node | nodeUidDisplay | truncate: 30 }}</div>
+<div class="node-column story-row-column">
+  <div id="{{ 'js-' + node.resource_type.toLowerCase() + '-node' }}" class="node-column__node" [ngClass]="{'node-column__node--active': active}" 
+      [routerLink]="['/', node.resource_type.toLowerCase(), getNodeUid()]"
       tooltip="{{ node.resource_type | nodeTypeDisplay }}: {{ node | nodeUidDisplay }}">
-    <img src="assets/circle_single.svg" />
-    <div class="mainItemIconContainer"><i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i></div>
+    <img class="node-column__node-img" src="assets/circle_single.svg"/>
+    <div class="node-column__node-icon"><i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i></div>
   </div>
 </div>
-<div *ngIf="relatedNodes" class="secondaryItem">
-  <div id="{{ node.resource_type + 'Secondary'}}"
-      tooltip="Related {{ node.resource_type | nodeTypeDisplay | nodeTypePlural }}">
-    <img src="assets/circle_multi.svg" />
-    <div class="secondaryItemIconContainer"><i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i></div>
+<div class="node-siblings-column story-row-column" *ngIf="relatedNodes" >
+  <div id="{{ 'js-' + node.resource_type.toLowerCase() + '-siblings' }}" class="node-column__siblings" tooltip="Related {{ node.resource_type | nodeTypeDisplay | nodeTypePlural }}">
+    <img class="node-column__siblings-img" src="assets/circle_multi.svg" />
+    <div class="node-siblings-column__node-icon"><i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i></div>
   </div>
 </div>
-<div *ngIf="relatedNodes" class="secondaryItemText">{{ relatedNodes + ' more' }}</div>
+<div class="node-siblings-text-column story-row-column" *ngIf="relatedNodes">{{ relatedNodes + ' more' }}</div>

--- a/src/app/story/storyrow/storyrow.component.spec.ts
+++ b/src/app/story/storyrow/storyrow.component.spec.ts
@@ -43,15 +43,15 @@ describe('StoryRowComponent testing', () => {
     tick();
 
     // Verify the text is correct
-    const mainItemTextEl = fixture.debugElement.query(By.css('.mainItemText')).nativeElement;
-    expect(mainItemTextEl.innerText).toBe('RHBZ#23456');
+    const nodeUidColEl = fixture.debugElement.query(By.css('.node-uid-column')).nativeElement;
+    expect(nodeUidColEl.innerText).toBe('RHBZ#23456');
 
-    const artifactEl = fixture.debugElement.query(By.css('#BugzillaBugPrimary')).nativeElement;
+    const nodeEl = fixture.debugElement.query(By.css('.node-column__node')).nativeElement;
     // Verify the artifact details are correct
-    expect(artifactEl.children[0].tagName).toBe('IMG');
-    expect(artifactEl.children[0].src).toContain('circle_single.svg');
-    expect(artifactEl.attributes['ng-reflect-tooltip'].value).toBe('Bugzilla Bug: RHBZ#23456');
-    expect(artifactEl.attributes['ng-reflect-router-link'].value).toBe('/,bugzillabug,23456');
+    expect(nodeEl.children[0].tagName).toBe('IMG');
+    expect(nodeEl.children[0].src).toContain('circle_single.svg');
+    expect(nodeEl.attributes['ng-reflect-tooltip'].value).toBe('Bugzilla Bug: RHBZ#23456');
+    expect(nodeEl.attributes['ng-reflect-router-link'].value).toBe('/,bugzillabug,23456');
   }));
 
   it('should display multiple artifacts', fakeAsync(() => {
@@ -62,17 +62,17 @@ describe('StoryRowComponent testing', () => {
     tick();
 
     // Verify the text is correct
-    const mainItemTextEl = fixture.debugElement.query(By.css('.mainItemText')).nativeElement;
-    expect(mainItemTextEl.innerText).toBe('RHBZ#23456');
+    const nodeUidColEl = fixture.debugElement.query(By.css('.node-uid-column')).nativeElement;
+    expect(nodeUidColEl.innerText).toBe('RHBZ#23456');
 
-    const secondaryArtifactEl = fixture.debugElement.query(By.css('#BugzillaBugSecondary')).nativeElement;
+    const siblingsEl = fixture.debugElement.query(By.css('.node-column__siblings')).nativeElement;
     // Verify the secondary artifact details are correct
-    expect(secondaryArtifactEl.children[0].tagName).toBe('IMG');
-    expect(secondaryArtifactEl.children[0].src).toContain('circle_multi.svg');
-    expect(secondaryArtifactEl.attributes['ng-reflect-tooltip'].value).toBe('Related Bugzilla Bugs');
+    expect(siblingsEl.children[0].tagName).toBe('IMG');
+    expect(siblingsEl.children[0].src).toContain('circle_multi.svg');
+    expect(siblingsEl.attributes['ng-reflect-tooltip'].value).toBe('Related Bugzilla Bugs');
 
-    const secondaryItemTextEl = fixture.debugElement.query(By.css('.secondaryItemText')).nativeElement;
-    expect(secondaryItemTextEl.innerText).toBe('5 more');
+    const siblingsTextEl = fixture.debugElement.query(By.css('.node-siblings-text-column')).nativeElement;
+    expect(siblingsTextEl.innerText).toBe('5 more');
   }));
 
   it('should call story.connectStory when it\'s the last row', fakeAsync(() => {

--- a/src/app/story/storysidebar/story.sidebar.component.spec.ts
+++ b/src/app/story/storysidebar/story.sidebar.component.spec.ts
@@ -48,11 +48,11 @@ describe('StorysidebarComponent testing', () => {
   }));
 
   it('should display the input node when the sidebar is open', fakeAsync(() => {
-    const titleAnchorEl = fixture.debugElement.query(By.css('#sidebar a[target="_blank"]')).nativeElement;
+    const titleAnchorEl = fixture.debugElement.query(By.css('.sidebar a[target="_blank"]')).nativeElement;
     expect(titleAnchorEl.href).toBe('https://bugzilla.redhat.com/show_bug.cgi?id=23456');
-    const titleEl = fixture.debugElement.query(By.css('#sidebar > a > h2')).nativeElement;
+    const titleEl = fixture.debugElement.query(By.css('.sidebar__external-system-link > h2')).nativeElement;
     expect(titleEl.textContent).toBe('RHBZ#23456');
-    const sidebarPropertiesEl = fixture.debugElement.query(By.css('#sidebarProperties > tbody')).nativeElement;
+    const sidebarPropertiesEl = fixture.debugElement.query(By.css('.sidebar-properties > tbody')).nativeElement;
     expect(sidebarPropertiesEl.children.length).toBe(20);
     expect(sidebarPropertiesEl.children[0].children[0].textContent).toBe('Assignee');
     expect(sidebarPropertiesEl.children[0].children[1].textContent).toBe('user1');
@@ -98,7 +98,7 @@ describe('StorysidebarComponent testing', () => {
   }));
 
   it('should truncate long property values', () => {
-    const sidebarPropertiesEl = fixture.debugElement.query(By.css('#sidebarProperties > tbody')).nativeElement;
+    const sidebarPropertiesEl = fixture.debugElement.query(By.css('.sidebar-properties > tbody')).nativeElement;
     // Make sure the expand/unexpand (truncate) button works
     const truncateAnchorEl = sidebarPropertiesEl.children[16].children[1].children[0];
     expect(truncateAnchorEl.tagName).toBe('A');
@@ -117,11 +117,11 @@ describe('StorysidebarComponent testing', () => {
     fixture.detectChanges();
     tick();
 
-    const titleAnchorEl = fixture.debugElement.query(By.css('#sidebar a[target="_blank"]'));
+    const titleAnchorEl = fixture.debugElement.query(By.css('.sidebar a[target="_blank"]'));
     expect(titleAnchorEl).toBeNull();
-    const titleEl = fixture.debugElement.query(By.css('#sidebar > a > h3'));
+    const titleEl = fixture.debugElement.query(By.css('.sidebar > a > h3'));
     expect(titleEl).toBeNull();
-    const sidebarPropertiesEl = fixture.debugElement.query(By.css('#sidebarProperties'));
+    const sidebarPropertiesEl = fixture.debugElement.query(By.css('.sidebar-properties'));
     expect(sidebarPropertiesEl).toBeNull();
   }));
 });

--- a/src/app/story/storysidebar/storysidebar.component.css
+++ b/src/app/story/storysidebar/storysidebar.component.css
@@ -1,13 +1,9 @@
-:host, #sidebarTitle a {
+/* ----- Blocks ----- */
+:host {
     color: #6A6C6F;
 }
 
-a > h2 {
-    /* This makes the h2 be on the same line as the wrapping anchor */
-    display: inline-block;
-}
-
-#sidebar {
+.sidebar {
     background-color: #FFFFFF;
     /* Position the sidebar on the right side of the page */
     position: absolute;
@@ -21,25 +17,7 @@ a > h2 {
     transition: width 0.5s;
 }
 
-#sidebar.open {
-    width: 100%;
-}
-
-#sidebar.closed {
-    width: 25px;
-}
-
-#sidebar.closed > * {
-    /* When the sidebar is closed, make the arrow closer to the edge */
-    margin-left: 0.75rem;
-}
-
-#sidebar > * {
-    /* Move all content in the sidebar over 2.5rem to not hug the border */
-    margin-left: 2.5rem;
-}
-
-#sidebarTitle {
+.sidebar-title {
     font-size: 1.6rem;
     font-weight: 600;
     /* Give some space around the arrow and "Properties" */
@@ -47,38 +25,41 @@ a > h2 {
     margin-bottom: 1rem;
 }
 
-#sidebar.open #sidebarTitle i {
-    /* Push "Properties" to the right 1rem */
-    margin-right: 1rem;
-}
-
-#sidebarTitle a {
-    /* Remove some of the default styles on the arrow */
-    outline: 0;
-    text-decoration: none;
-}
-
-#sidebar > a > h2 {
-    font-weight: bold;
-}
-
-#sidebarProperties {
+.sidebar-properties {
     margin-top: 1rem;
     margin-right: 1rem;
     margin-bottom: 3rem;
     padding-right: 1rem;
 }
 
-.sidebarPropertiesRow {
+/* ----- Elements ----- */
+.sidebar > * {
+    margin-left: 2.5rem;
+}
+
+.sidebar-title__arrow {
+    /* Remove some of the default styles on the arrow */
+    outline: 0;
+    text-decoration: none;
+    color: #6A6C6F;
+}
+
+.sidebar__external-system-link > h2 {
+    /* This makes the h2 be on the same line as the wrapping anchor */
+    display: inline-block;
+    font-weight: bold;
+}
+
+.sidebar-properties__row {
     font-size: 1.3rem;
 }
 
-.sidebarPropertiesRow > td {
+.sidebar-properties__row > td {
     word-break: break-all;
     padding-bottom: 0.5rem;
 }
 
-.sidebarPropertiesRow td:nth-child(odd) {
+.sidebar-properties__key-column {
     /* If the value to the right is more than one line, don't vertically center the key */
     vertical-align: top;
     /* Create some space between the key and the value */
@@ -87,35 +68,56 @@ a > h2 {
     white-space: nowrap;
 }
 
-.sidebarPropertiesRow td:nth-child(even) {
+.sidebar-properties__value-column {
     /* Bold the values in the table */
     font-weight: bold;
 }
 
-.truncateArrow {
+.sidebar-properties__truncate-arrow {
     /* Create some space between the text and the truncate arrow */
     margin-left: 0.5rem;
 }
 
 @media (min-width: 992px) {
-    #sidebar.open {
+    .sidebar > * {
+        margin-left: 3rem;
+    }
+
+    .sidebar-properties {
+        margin-right: 2rem;
+    }
+
+    .sidebar-properties__key-column {
+        padding-right: 2rem;
+    }
+}
+
+/* ----- Modifiers ----- */
+.sidebar--open {
+    width: 100%;
+}
+
+.sidebar--closed {
+    width: 25px;
+}
+
+.sidebar--closed > * {
+    /* When the sidebar is closed, make the arrow closer to the edge */
+    margin-left: 0.75rem;
+}
+
+.sidebar--open .sidebar-title i {
+    /* Push "Properties" to the right 1rem */
+    margin-right: 1rem;
+}
+
+@media (min-width: 992px) {
+    .sidebar--open {
         width: 45%;
         max-width: 750px;
     }
 
-    #sidebar.closed {
+    .sidebar--closed {
         width: 30px;
-    }
-
-    #sidebar > * {
-        margin-left: 3rem;
-    }
-
-    .sidebarPropertiesRow td:nth-child(odd) {
-        padding-right: 2rem;
-    }
-
-    #sidebarProperties {
-        margin-right: 2rem;
     }
 }

--- a/src/app/story/storysidebar/storysidebar.component.html
+++ b/src/app/story/storysidebar/storysidebar.component.html
@@ -1,6 +1,6 @@
-<div id="sidebar" [ngClass]="{'open': sidebarOpen, 'closed': !sidebarOpen}">
-  <div id="sidebarTitle">
-    <a href="#" (click)="sidebarOpen = !sidebarOpen; $event.preventDefault()">
+<div class="sidebar" [ngClass]="{'sidebar--open': sidebarOpen, 'sidebar--closed': !sidebarOpen}">
+  <div class="sidebar-title">
+    <a class="sidebar-title__arrow" href="#" (click)="sidebarOpen = !sidebarOpen; $event.preventDefault()">
       <i [ngClass]="{'fa-angle-double-right': sidebarOpen, 'fa-angle-double-left': !sidebarOpen}"
           class="fa fa-th" aria-hidden="true">
       </i>
@@ -8,7 +8,7 @@
     <ng-container *ngIf="sidebarOpen">Properties</ng-container>
   </div>
   <ng-container *ngIf="sidebarOpen && node">
-    <a [href]="node | nodeExternalUrl" target="_blank">
+    <a class="sidebar__external-system-link" [href]="node | nodeExternalUrl" target="_blank">
       <!-- *ngIf is used because it should only tooltip on long UIDs -->
       <h2 *ngIf="(node | nodeUidDisplay).length > 30; else shortUid" tooltip="{{ node | nodeUidDisplay }}">
         {{ node | nodeUidDisplay | truncate: 30 }}
@@ -17,15 +17,16 @@
         <h2>{{ node | nodeUidDisplay }}</h2>
       </ng-template>
     </a>
-    <table id="sidebarProperties">
+    <table class="sidebar-properties">
       <tbody>
-        <tr *ngFor="let prop of properties; let i = index" class="sidebarPropertiesRow">
-          <td>{{ prop.name | propertyDisplay }}</td>
-          <td>
+        <tr class="sidebar-properties__row" *ngFor="let prop of properties; let i = index">
+          <td class="sidebar-properties__key-column">{{ prop.name | propertyDisplay }}</td>
+          <td class="sidebar-properties__value-column">
             <ng-container *ngIf="prop.truncate">{{ prop.value | truncate }}</ng-container>
             <ng-container *ngIf="!prop.truncate">{{ prop.value }}</ng-container>
             <ng-container *ngIf="prop.needsTruncating">
-              <a (click)="prop.truncate = !prop.truncate; $event.preventDefault()" *ngIf="prop.needsTruncating" href="#" class="truncateArrow">
+              <a class="sidebar-properties__truncate-arrow" (click)="prop.truncate = !prop.truncate; $event.preventDefault()"
+                  *ngIf="prop.needsTruncating" href="#">
                 <i [ngClass]="{'fa-angle-down': prop.truncate, 'fa-angle-up': !prop.truncate}" class="fa fa-th" aria-hidden="true"></i>
               </a>
             </ng-container>


### PR DESCRIPTION
This PR transitions the code-base to conform to [BEM styling](http://getbem.com/introduction/) which adds readability to the CSS and makes it easier to make updates to the CSS in the future due to improvements to specificity. Classes are now favored over IDs due to [specificity headaches](https://csswizardry.com/2011/09/when-using-ids-can-be-a-pain-in-the-class/). Any ID or class that is not used for styling but only for JavaScript targeting, now start with the "js-" prefix.

There is no actual change to the content or styles in this PR, just cosmetic changes to the code.