### PR TITLE
Make the siblings smaller

### DIFF
--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -81,22 +81,20 @@ describe('StoryComponent testing', () => {
     expect(storyRowEls.length).toBe(6);
 
     // Ensure the number of columns in the row
-    expect(storyRowEls[0].nativeElement.children.length).toBe(4);
+    expect(storyRowEls[0].nativeElement.children.length).toBe(3);
     // Ensure the text is correct
     expect(storyRowEls[0].nativeElement.firstElementChild.innerText).toBe('RHBZ#12345');
     // Ensure the order is correct
     expect(storyRowEls[0].nativeElement.children[1].firstElementChild.id).toBe('js-bugzillabug-node');
     // Ensure the Bugzilla Bug is the active one
     expect(storyRowEls[0].nativeElement.children[1].firstElementChild.classList).toContain('node-column__node--active');
-    // Ensure a secondary Bugzilla Bug is shown
-    expect(storyRowEls[0].nativeElement.children[2].firstElementChild.id).toBe('js-bugzillabug-siblings');
-    // Ensure the secondary Bugzilla Bug text is shown and the link is correct
-    expect(storyRowEls[0].nativeElement.children[3].innerText).toBe('1 more');
-    const siblingsAnchor = storyRowEls[0].nativeElement.children[3].children[0];
-    expect(siblingsAnchor.tagName).toBe('A');
-    const expSiblingsUrl = 'http://localhost:9876/siblings/distgitcommit/8a63adb248ba633e200067e1ad6dc61931727bad?' +
-                           'displayName=RHBZ%2312345&reverse=false';
-    expect(siblingsAnchor.href).toBe(expSiblingsUrl);
+    // Ensure there are Bugzilla Bug siblings shown
+    const siblingsDivEl = storyRowEls[0].nativeElement.querySelector('.node-siblings-column__siblings');
+    expect(siblingsDivEl.id).toBe('js-bugzillabug-siblings');
+    expect(siblingsDivEl.attributes.getNamedItem('ng-reflect-query-params')).toBeTruthy();
+    expect(siblingsDivEl.attributes.getNamedItem('ng-reflect-router-link').value).toBe('/siblings/distgitcommit/8a63ad');
+    const siblingsBadgeEl = storyRowEls[0].nativeElement.querySelector('.node-siblings-column__badge');
+    expect(siblingsBadgeEl.innerText).toBe('+1');
 
     // Ensure the number of columns in the row
     expect(storyRowEls[1].nativeElement.children.length).toBe(2);

--- a/src/app/story/storyrow/storyrow.component.css
+++ b/src/app/story/storyrow/storyrow.component.css
@@ -24,8 +24,8 @@
 }
 
 .node-column {
-    /* Leave a decent gap between the main node and the siblings */
-    padding-right: 5rem;
+    /* Leave a small gap between the main node and the siblings */
+    padding-right: 1rem;
 }
 
 .node-siblings-text-column {
@@ -43,6 +43,13 @@
     .node-siblings-column {
         /* Leave a small gap between the siblings and the "x more" text  */
         padding-right: 1.25rem;
+    }
+}
+
+@media (min-width: 992px) {
+    .node-column {
+        /* Leave a larger gap between the main node and the siblings */
+        padding-right: 2.5rem;
     }
 }
 
@@ -84,13 +91,13 @@
 }
 
 .node-column__node-icon {
+     /* Make the icons larger */
+     font-size: 2.25rem;
     /* Place the icon halfway to the left of the circle */
     left: 50%;
 }
 
 .node-column__node-icon, .node-siblings-column__node-icon {
-    /* Make the icons larger */
-    font-size: 2.25rem;
     position: absolute;
     /* Place the icon halfway down the circle */
     top: 50%;
@@ -99,14 +106,17 @@
 }
 
 .node-siblings-column__node-icon {
+    /* Make the icons larger but smaller than the main node column */
+    font-size: 1.8rem;
     /* Place the icon roughly a third to the left of the circle */
     left: 36.6%;
 }
 
 .node-column__siblings {
-    width: 96px;
-    height: 66px;
+    width: 73px;
+    height: 50px;
 }
+
 
 /* ----- Modifiers ----- */
 .node-column__node--active, .node-column__node--active:hover  {

--- a/src/app/story/storyrow/storyrow.component.css
+++ b/src/app/story/storyrow/storyrow.component.css
@@ -15,9 +15,6 @@
     text-align: right;
     /* Leave a gap next to the main node */
     padding-right: 1.5rem;
-}
-
-.node-uid-column, .node-siblings-text-column {
     position: relative;
     /* Vertically center the text */
     top: 5px;
@@ -28,27 +25,16 @@
     padding-right: 1rem;
 }
 
-.node-siblings-text-column {
-    /* Don't show the "x more" text on mobile */
-    display: none;
-}
-
-/* Roughly a small phone in landscape mode */
-@media (min-width : 550px) {
-    .node-siblings-text-column {
-        /* Display the "x more" text */
-        display: block;
-    }
-
-    .node-siblings-column {
-        /* Leave a small gap between the siblings and the "x more" text  */
-        padding-right: 1.25rem;
-    }
+/* Assumes the Bootstrap badge class is also applied */
+.siblings-badge {
+    border-radius: 1rem;
+    background-color: #0088ce;
+    margin: 0;
 }
 
 @media (min-width: 992px) {
     .node-column {
-        /* Leave a larger gap between the main node and the siblings */
+        /* Leave a larger gap between the main node and the siblings when on a tablet or larger */
         padding-right: 2.5rem;
     }
 }
@@ -65,27 +51,23 @@
     margin-left: 2px;
 }
 
-.node-column__node, .node-column__siblings {
+.node-column__node, .node-siblings-column__siblings {
     /* Make the position relative so that the icons can be absolutely positioned within it */
     position: relative;
 }
 
-.node-column__node:hover {
+.node-column__node:hover, .node-siblings-column__siblings:hover {
     /* Make the mouse look like a pointer so the user intuitively knows they can click on the shape */
     cursor: pointer;
     outline: 0;
-    /* Add a thin border when hovering over the node */
-    border: 3px solid #0088cc;
-    /* Hides the shadow effect of node's SVG while it is being bordered */
-    background-color: #FFFFFF;
+    color: #000000;
 }
 
-.node-column__node:hover .node-column__node-img {
-    /* Hides the shadow effect of node's img while it is being bordered */
-    opacity: 0;
+.node-siblings-column__siblings:hover .node-siblings-column__badge {
+    background-color: #00659c;
 }
 
-.node-column__node-img, .node-column__siblings-img {
+.node-column__node-img, .node-siblings-column__siblings-img {
     /* Make the images take up the whole div that has a fixed size */
     height: 100%;
 }
@@ -109,12 +91,18 @@
     /* Make the icons larger but smaller than the main node column */
     font-size: 1.8rem;
     /* Place the icon roughly a third to the left of the circle */
-    left: 36.6%;
+    left: 33%;
 }
 
-.node-column__siblings {
-    width: 73px;
+.node-siblings-column__siblings {
+    width: 80px;
     height: 50px;
+}
+
+.node-siblings-column__badge {
+    position: absolute;
+    top: 16.5px;
+    right: 0px;
 }
 
 

--- a/src/app/story/storyrow/storyrow.component.html
+++ b/src/app/story/storyrow/storyrow.component.html
@@ -7,12 +7,14 @@
     <div class="node-column__node-icon"><i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i></div>
   </div>
 </div>
-<div class="node-siblings-column story-row-column" *ngIf="relatedNodes" >
-  <div id="{{ 'js-' + node.resource_type.toLowerCase() + '-siblings' }}" class="node-column__siblings" tooltip="Related {{ node.resource_type | nodeTypeDisplay | nodeTypePlural }}">
-    <img class="node-column__siblings-img" src="assets/circle_multi.svg" />
-    <div class="node-siblings-column__node-icon"><i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i></div>
+<div class="node-siblings-column story-row-column" *ngIf="relatedNodes">
+  <div id="{{ 'js-' + node.resource_type.toLowerCase() + '-siblings' }}" class="node-siblings-column__siblings"
+      tooltip="Related {{ node.resource_type | nodeTypeDisplay | nodeTypePlural }}"
+      [routerLink]="siblingsRouterLink" [queryParams]="siblingsRouterParams">
+    <img class="node-siblings-column__siblings-img" src="assets/circle_multi.svg" />
+    <div class="badge siblings-badge node-siblings-column__badge">+{{ relatedNodes }}</div>
+    <div class="node-siblings-column__node-icon">
+      <i class="fa fa-th {{ getNodeIconClass() }}" aria-hidden="true"></i>
+    </div>
   </div>
-</div>
-<div class="node-siblings-text-column story-row-column" *ngIf="relatedNodes">
-  <a [routerLink]="siblingsRouterLink" [queryParams]="siblingsRouterParams">{{ relatedNodes }} more</a>
 </div>

--- a/src/app/story/storyrow/storyrow.component.spec.ts
+++ b/src/app/story/storyrow/storyrow.component.spec.ts
@@ -65,14 +65,15 @@ describe('StoryRowComponent testing', () => {
     const nodeUidColEl = fixture.debugElement.query(By.css('.node-uid-column')).nativeElement;
     expect(nodeUidColEl.innerText).toBe('RHBZ#23456');
 
-    const siblingsEl = fixture.debugElement.query(By.css('.node-column__siblings')).nativeElement;
-    // Verify the secondary artifact details are correct
+    const siblingsEl = fixture.debugElement.query(By.css('.node-siblings-column__siblings')).nativeElement;
+    // Verify the siblings are correct
+    expect(siblingsEl.attributes['ng-reflect-tooltip'].value).toBe('Related Bugzilla Bugs');
     expect(siblingsEl.children[0].tagName).toBe('IMG');
     expect(siblingsEl.children[0].src).toContain('circle_multi.svg');
-    expect(siblingsEl.attributes['ng-reflect-tooltip'].value).toBe('Related Bugzilla Bugs');
-
-    const siblingsTextEl = fixture.debugElement.query(By.css('.node-siblings-text-column')).nativeElement;
-    expect(siblingsTextEl.innerText).toBe('5 more');
+    // Verify the badge with "+x" is correct
+    const siblingsBadgeEl = siblingsEl.querySelector('.node-siblings-column__badge');
+    expect(siblingsBadgeEl.tagName).toBe('DIV');
+    expect(siblingsBadgeEl.innerText).toBe('+5');
   }));
 
   it('should call story.connectStory when it\'s the last row', fakeAsync(() => {


### PR DESCRIPTION
In preparation of introducing another siblings column, we must make the siblings smaller. This PR consolidates the "x more" column to be a badge that floats on top of the siblings shape.

![image](https://user-images.githubusercontent.com/11711106/42699884-1c7e71d4-8690-11e8-9ff0-c03fda30474b.png)