### PR TITLE
Stop running split on null node display names

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -9,7 +9,8 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { SearchComponent } from './search/search.component';
 import { AlertComponent } from './alert/alert.component';
-import { NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe, TruncatePipe } from './pipes/nodedisplay';
+import { NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe, TruncatePipe,
+         NodeDisplayNamePipe } from './pipes/nodedisplay';
 import { PropertyDisplayPipe } from './pipes/propertydisplay';
 import { StoryComponent } from './story/story.component';
 import { StoryRowComponent } from './story/storyrow/storyrow.component';
@@ -60,7 +61,8 @@ describe('AppComponent', () => {
         StoryComponent,
         StoryRowComponent,
         StorysidebarComponent,
-        TruncatePipe
+        TruncatePipe,
+        NodeDisplayNamePipe
       ],
       imports: [
         AppRoutingModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,7 +17,7 @@ import { StoryRowComponent } from './story/storyrow/storyrow.component';
 import { StorysidebarComponent } from './story/storysidebar/storysidebar.component';
 import { PropertyDisplayPipe, PropertyValueDisplayPipe } from './pipes/propertydisplay';
 import { NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe,
-         TruncatePipe } from './pipes/nodedisplay';
+         TruncatePipe, NodeDisplayNamePipe } from './pipes/nodedisplay';
 import { SearchComponent } from './search/search.component';
 import { AlertComponent } from './alert/alert.component';
 import { SpinnerComponent } from './spinner/spinner.component';
@@ -46,7 +46,8 @@ import { environment } from '../environments/environment';
     SiblingsComponent,
     PropertyValueDisplayPipe,
     ArtifactsTableComponent,
-    ArtifactRelationshipComponent
+    ArtifactRelationshipComponent,
+    NodeDisplayNamePipe
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/pipes/nodedisplay.ts
+++ b/src/app/pipes/nodedisplay.ts
@@ -84,3 +84,16 @@ export class TruncatePipe implements PipeTransform {
       }
   }
 }
+
+
+@Pipe({name: 'nodeDisplayName'})
+export class NodeDisplayNamePipe implements PipeTransform {
+    // This Pipe takes a node's display_name as input and only shows the identifier
+    // and not the prefixes. The displayName type is any because `null` is also accepted.
+    transform(displayName: any): string {
+        if (!displayName) {
+            return '';
+        }
+        return displayName.split(' ').slice(-1)[0];
+    }
+}

--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -16,7 +16,7 @@ import { AlertComponent } from '../alert/alert.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe,
-         TruncatePipe } from '../pipes/nodedisplay';
+         TruncatePipe, NodeDisplayNamePipe } from '../pipes/nodedisplay';
 import { PropertyDisplayPipe } from '../pipes/propertydisplay';
 import { StoryService } from '../services/story.service';
 import { bug, story, module_story } from './test.data';
@@ -42,7 +42,8 @@ describe('StoryComponent testing', () => {
             TruncatePipe,
             AlertComponent,
             SpinnerComponent,
-            NavbarComponent
+            NavbarComponent,
+            NodeDisplayNamePipe
         ],
         providers: [
             StoryService,

--- a/src/app/story/storyrow/storyrow.component.html
+++ b/src/app/story/storyrow/storyrow.component.html
@@ -1,8 +1,8 @@
-<div class="node-uid-column story-row-column">{{ (node.display_name.split(' ') | slice:-1)[0] | truncate: 30 }}</div>
+<div class="node-uid-column story-row-column">{{ node.display_name | nodeDisplayName | truncate: 30 }}</div>
 <div class="node-column story-row-column">
   <div id="{{ 'js-' + node.resource_type.toLowerCase() + '-node' }}" class="node-column__node" [ngClass]="{'node-column__node--active': active}" 
       [routerLink]="['/', node.resource_type.toLowerCase(), getNodeUid()]"
-      tooltip="{{ node.resource_type | nodeTypeDisplay }} {{ (node.display_name.split(' ') | slice:-1)[0] }}">
+      tooltip="{{ node.resource_type | nodeTypeDisplay }} {{ node.display_name | nodeDisplayName }}">
     <img class="node-column__node-img" src="assets/circle_single.svg" />
     <div class="node-column__node-icon"><i [ngClass]="iconClasses" aria-hidden="true"></i></div>
   </div>

--- a/src/app/story/storyrow/storyrow.component.spec.ts
+++ b/src/app/story/storyrow/storyrow.component.spec.ts
@@ -6,7 +6,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { StoryRowComponent } from './storyrow.component';
 import { bug } from '../test.data';
-import { NodeTypeDisplayPipe, NodeTypePluralPipe, TruncatePipe } from '../../pipes/nodedisplay';
+import { NodeTypeDisplayPipe, NodeTypePluralPipe, TruncatePipe, NodeDisplayNamePipe } from '../../pipes/nodedisplay';
 import { StoryComponent } from '../story.component';
 
 
@@ -20,7 +20,8 @@ describe('StoryRowComponent testing', () => {
             StoryRowComponent,
             NodeTypeDisplayPipe,
             NodeTypePluralPipe,
-            TruncatePipe
+            TruncatePipe,
+            NodeDisplayNamePipe
         ],
         providers: [
           {provide: StoryComponent, useValue: {connectStory: () => {}}}

--- a/src/app/story/storysidebar/story.sidebar.component.spec.ts
+++ b/src/app/story/storysidebar/story.sidebar.component.spec.ts
@@ -3,7 +3,7 @@ import { DatePipe } from '@angular/common';
 import { ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
 
 import { StorysidebarComponent } from './storysidebar.component';
-import { NodeExternalUrlPipe, TruncatePipe } from '../../pipes/nodedisplay';
+import { NodeExternalUrlPipe, TruncatePipe, NodeDisplayNamePipe } from '../../pipes/nodedisplay';
 import { PropertyDisplayPipe, PropertyValueDisplayPipe } from '../../pipes/propertydisplay';
 import { bug } from '../test.data';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
@@ -21,7 +21,8 @@ describe('StorysidebarComponent testing', () => {
             NodeExternalUrlPipe,
             PropertyDisplayPipe,
             PropertyValueDisplayPipe,
-            TruncatePipe
+            TruncatePipe,
+            NodeDisplayNamePipe
         ],
         providers: [
           DatePipe

--- a/src/app/story/storysidebar/storysidebar.component.html
+++ b/src/app/story/storysidebar/storysidebar.component.html
@@ -10,11 +10,11 @@
   <ng-container *ngIf="sidebarOpen && node">
     <a class="sidebar__external-system-link" [href]="node | nodeExternalUrl" target="_blank">
       <!-- *ngIf is used because it should only tooltip on long UIDs -->
-      <h2 *ngIf="(node.display_name.split(' ') | slice:-1)[0].length > 30; else shortUid" tooltip="{{ (node.display_name.split(' ') | slice:-1)[0] }}">
-        {{ (node.display_name.split(' ') | slice:-1)[0] | truncate: 30 }}
+      <h2 *ngIf="(node.display_name | nodeDisplayName).length > 30; else shortUid" tooltip="{{ node.display_name | nodeDisplayName }}">
+        {{ node.display_name | nodeDisplayName | truncate: 30 }}
       </h2>
       <ng-template #shortUid>
-        <h2>{{ (node.display_name.split(' ') | slice:-1)[0] }}</h2>
+        <h2>{{ node.display_name | nodeDisplayName }}</h2>
       </ng-template>
     </a>
     <table class="sidebar-properties">


### PR DESCRIPTION
Occasionally, a node's display name is null and therefore, the split method fails since it's not a method on null values. This abstracts the use of the split method to a reusable pipe. This has the added benefit of reducing code duplication.