### PR TITLE
Show only last Greenwave result

### DIFF
--- a/src/app/story/test.data.ts
+++ b/src/app/story/test.data.ts
@@ -533,6 +533,30 @@ export const greenwaveDecision: GreenwaveDecision = {
       'groups': [
         'b6d8bbeb-a7ea-4bc3-b062-25eb8f404b2e'
       ],
+      'href': 'https://resultsdb.domain.local/api/v2.0/results/6125318',
+      'id': 6125318,
+      'note': '',
+      'outcome': 'PASSED',
+      'ref_url': 'https://jenkins.domain.local/job/cvp-product-test/1/',
+      'submit_time': '2018-08-01T19:03:49.074767',
+      'testcase': {
+        'href': 'https://resultsdb.domain.local/api/v2.0/testcases/rhproduct.default.sanity',
+        'name': 'rhproduct.default.sanity',
+        'ref_url': 'https://jenkins.domain.local/'
+      }
+    },
+    {
+      'data': {
+        'item': [
+          'cfme-openshift-app-ui-container-5.9.3.4-1.1533127933'
+        ],
+        'log': [
+          'https://jenkins.domain.local/job/cvp-product-test/1/console'
+        ],
+      },
+      'groups': [
+        'b6d8bbeb-a7ea-4bc3-b062-25eb8f404b2e'
+      ],
       'href': 'https://resultsdb.domain.local/api/v2.0/results/6125319',
       'id': 6125319,
       'note': '',

--- a/src/app/tables/tests-table/tests-table.component.ts
+++ b/src/app/tables/tests-table/tests-table.component.ts
@@ -47,28 +47,37 @@ export class TestsTableComponent implements OnChanges {
       .filter(waiver => waiver.waived)
       .map(waiver => waiver.testcase);
 
-    this.formattedResults = this.greenwaveDecision.results.map(result => {
-      const formattedResult = {
-        'ID': result.id,
-        'Item': result.data.item,
-        'Status': result.outcome,
-        'Test Case': result.testcase.name,
-        'Logs': 'No logs available',
-        'Waived': waivedTestCases.includes(result.testcase.name) ? 'Yes' : 'No',
-      };
+    const sortedResults = this.greenwaveDecision.results.slice().sort((a, b) => {
+      return new Date(a.submit_time) > new Date(b.submit_time) ? -1 : (new Date(b.submit_time) > new Date(a.submit_time) ? 1 : 0);
+    });
+    const processedTestCases = [];
+    for (const result of sortedResults) {
+      /* showing only the last result */
+      if (!processedTestCases.includes(result.testcase.name)) {
+        const formattedResult = {
+          'ID': result.id,
+          'Item': result.data.item,
+          'Status': result.outcome,
+          'Test Case': result.testcase.name,
+          'Logs': 'No logs available',
+          'Waived': waivedTestCases.includes(result.testcase.name) ? 'Yes' : 'No',
+        };
 
-      this.linkColumnMappings[result.id] = {
-        'ID': result.href,
-        'Test Case': result.testcase.href,
-      };
+        this.linkColumnMappings[result.id] = {
+          'ID': result.href,
+          'Test Case': result.testcase.href,
+        };
 
-      if (result.data.log) {
-        formattedResult['Logs'] = 'Test Run Logs';
-        this.linkColumnMappings[result.id]['Logs'] = result.data.log;
+        if (result.data.log) {
+          formattedResult['Logs'] = 'Test Run Logs';
+          this.linkColumnMappings[result.id]['Logs'] = result.data.log;
+        }
+
+        this.formattedResults.push(formattedResult);
+        processedTestCases.push(result.testcase.name);
       }
 
-      return formattedResult;
-    });
+    }
   }
 
   onChildError(errorMsg: string) {


### PR DESCRIPTION
Some Greenwave gating decisions return multiple results per testcase.
With this change Estuary shows only the latest result per testcase.