### PR TITLE
Display Greenwave gating decisions on module builds

### DIFF
--- a/src/app/services/greenwave.service.spec.ts
+++ b/src/app/services/greenwave.service.spec.ts
@@ -65,6 +65,13 @@ describe('GreenwaveService testing', () => {
       'yum-utils-1.1.31-46.el8', 'osci_compose_gate', 'rhel-8', 'koji_build', true);
   });
 
+  it('getArtifactDecision calls getDecision correctly with a ModuleKojiBuild', () => {
+    spyOn(greenwaveService, 'getDecision');
+    greenwaveService.getArtifactDecision('modulekojibuild', '389-ds-1.4-820190111173433.9edba152');
+    expect(greenwaveService.getDecision).toHaveBeenCalledWith(
+      '389-ds-1.4-820190111173433.9edba152', 'osci_compose_gate_modules', 'rhel-8', 'redhat-module', true);
+  });
+
   it('can parse the RHEL version from an NVR', () => {
     expect(greenwaveService.getProductVersionFromNVR('yum-utils-1.1.31-46.el7_5')).toBe('rhel-7');
   });

--- a/src/app/services/greenwave.service.ts
+++ b/src/app/services/greenwave.service.ts
@@ -72,7 +72,7 @@ export class GreenwaveService {
   getArtifactDecision(resource: string, subjectIdentifier: string, verbose = true): Observable<any> {
     let decisionContext: string;
     let productVersion: string;
-    const subjectType = 'koji_build';
+    let subjectType = 'koji_build';
 
     switch (resource.toLowerCase()) {
       case('containerkojibuild'):
@@ -90,6 +90,11 @@ export class GreenwaveService {
           // since the caller expects an observable to be returned
           return emptyObservable;
         }
+        break;
+      case('modulekojibuild'):
+        decisionContext = 'osci_compose_gate_modules';
+        productVersion = 'rhel-8';
+        subjectType = 'redhat-module';
         break;
       default:
         return emptyObservable;


### PR DESCRIPTION
Support for gating on module builds in Greenwave was recently added
with a new subject_type "redhat-module". With this change also
these data are going to be showed by Estuary.