### PR TITLE
Rename triggered_container_builds to successful_koji_builds

### DIFF
--- a/src/app/pipes/propertydisplay.ts
+++ b/src/app/pipes/propertydisplay.ts
@@ -10,6 +10,7 @@ export class PropertyDisplayPipe implements PipeTransform {
     if (property === 'id') {
       return property.toUpperCase();
     }
+    property = property.replace('koji', 'brew');
     const rvArray = property.toLowerCase().replace(/_/g, ' ').split(' ');
     for (let i = 0; i < rvArray.length; i++) {
       rvArray[i] = rvArray[i].charAt(0).toUpperCase() + rvArray[i].slice(1);

--- a/src/app/tables/artifacts-table/artifacts-table.component.ts
+++ b/src/app/tables/artifacts-table/artifacts-table.component.ts
@@ -99,7 +99,7 @@ export class ArtifactsTableComponent implements OnChanges {
         columns = ['advisory_name', 'assigned_to', 'id', 'security_impact', 'state', 'synopsis'];
         break;
       case ('freshmakerevent'):
-        columns = ['id', 'state_name', 'state_reason', 'triggered_container_builds'];
+        columns = ['id', 'state_name', 'state_reason', 'successful_koji_builds'];
         break;
       case ('distgitrepo'):
         columns = ['commits', 'name', 'namespace'];


### PR DESCRIPTION
Also failed and in-progress container builds are going to be displayed
in the future (not only successful once). For this reason let's rename
the FreshmakerEvent.triggered_container_builds field.