### PR TITLE
Fix the sidebar CSS on tablets and smaller

### DIFF
--- a/src/app/story/storysidebar/storysidebar.component.css
+++ b/src/app/story/storysidebar/storysidebar.component.css
@@ -95,6 +95,10 @@
     width: 100%;
 }
 
+.sidebar--closed {
+    width: 25px;
+}
+
 .sidebar--closed > * {
     /* When the sidebar is closed, make the arrow closer to the edge */
     margin-left: 0.75rem;
@@ -103,4 +107,11 @@
 .sidebar--open .sidebar-title i {
     /* Push "Properties" to the right 1rem */
     margin-right: 1rem;
+}
+
+@media (min-width: 992px) {
+    .sidebar--open {
+        width: 45%;
+        max-width: 750px;
+    }
 }

--- a/src/app/story/storysidebar/storysidebar.component.ts
+++ b/src/app/story/storysidebar/storysidebar.component.ts
@@ -17,7 +17,7 @@ import { PropertyValueDisplayPipe } from '../../pipes/propertydisplay';
           width: '25px'
         }),
       ),
-      transition('closed => open', animate('0.5s ease-out')),
+      transition('closed => open', animate('0.3s ease-out')),
     ])
   ]
 })

--- a/src/app/story/storysidebar/storysidebar.component.ts
+++ b/src/app/story/storysidebar/storysidebar.component.ts
@@ -11,19 +11,13 @@ import { PropertyValueDisplayPipe } from '../../pipes/propertydisplay';
   styleUrls: ['./storysidebar.component.css'],
   animations: [
     trigger('slideInSlideOut', [
-      state('open',
-        style({
-          maxWidth: '750px',
-          width: '45%'
-        }),
-      ),
+      state('open', style({})),
       state('closed',
         style({
           width: '25px'
         }),
       ),
-      transition('* => open', animate('0.5s ease-out', style({width: '45%', maxWidth: '750px'}))),
-      transition('* => closed', animate('0.3s ease-out', style({width: '25px'}))),
+      transition('closed => open', animate('0.5s ease-out')),
     ])
   ]
 })


### PR DESCRIPTION
When transitioning to Angular for the sidebar animation, the
CSS media query wasn't taken into account. This approach will
keep the improvements to the animation, but the drawback is that
when closing the sidebar, it is no longer animated.