### PR TITLE
Truncate the artifact display name at 25 characters in the desktop view

### DIFF
--- a/src/app/story/storyrow/storyrow.component.html
+++ b/src/app/story/storyrow/storyrow.component.html
@@ -1,5 +1,5 @@
 <div class="node-uid-column story-row-column">
-  <div class="node-uid-column__display-name node-uid-column__display-name--desktop">{{ node.display_name | nodeDisplayName | truncate: 30 }}</div>
+  <div class="node-uid-column__display-name node-uid-column__display-name--desktop">{{ node.display_name | nodeDisplayName | truncate: 25 }}</div>
   <div class="node-uid-column__display-name node-uid-column__display-name--mobile">{{ node.display_name | nodeDisplayName | truncate: 15 }}</div>
   <div class="node-uid-column__timestamp" *ngIf="node.timeline_timestamp; else noTimestamp">
     {{ node.timeline_timestamp | date: 'MMM d, y, HH:mm:ss':'+0000' }} <span class="node-uid-column__timestamp__timezone">UTC</span>


### PR DESCRIPTION
This resolves an issue where long display names would take up more than one line and it would make other parts of the page off center.