### PR TITLE
Add link to artifact story in tables

### DIFF
--- a/src/app/tables/artifacts-table/artifacts-table.component.html
+++ b/src/app/tables/artifacts-table/artifacts-table.component.html
@@ -8,4 +8,5 @@
     [linkColumnMappings]="linkColumnMappings"
     [defaultSortedColumn]="defaultSortedColumn"
     [tableSpacing]="tableSpacing"
+    sideColumnName="See Story"
 ></app-table>

--- a/src/app/tables/artifacts-table/artifacts-table.component.spec.ts
+++ b/src/app/tables/artifacts-table/artifacts-table.component.spec.ts
@@ -70,7 +70,7 @@ describe('ArtifactsTableComponent', () => {
 
     // Ensure the table headers show only the default columns
     const tableHeaders = fixture.debugElement.queryAll(By.css('.estuary-table th'));
-    expect(tableHeaders.length).toBe(6);
+    expect(tableHeaders.length).toBe(7);
     const tableHeadersText = tableHeaders.map(v => v.nativeElement.textContent.trim());
     expect(tableHeadersText[0]).toBe('Assignee');
     expect(tableHeadersText[1]).toBe('ID');
@@ -99,6 +99,8 @@ describe('ArtifactsTableComponent', () => {
     expect(rowOneColumns[3].textContent.trim()).toBe('user1');
     expect(rowOneColumns[4].textContent.trim()).toBe('CVE-2018-1234 kernel: some error [rhel-7.5.z]');
     expect(rowOneColumns[5].textContent.trim()).toBe('CLOSED');
+    expect(rowOneColumns[6].textContent.trim()).toBe('See Story');
+    expect(rowOneColumns[6].children[0].href).toContain('/bugzillabug/1566849');
 
     const rowTwoColumns = rows[1].nativeElement.children;
     expect(rowTwoColumns[0].textContent.trim()).toBe('user2');
@@ -115,6 +117,8 @@ describe('ArtifactsTableComponent', () => {
     expect(rowTwoColumns[4].textContent.trim()).toBe('CVE-2018-1235 kernel: some really long error that …');
     expect(rowTwoColumns[4].firstElementChild.tagName).toBe('APP-TRUNCATE-MODAL');
     expect(rowTwoColumns[5].textContent.trim()).toBe('CLOSED');
+    expect(rowTwoColumns[6].textContent.trim()).toBe('See Story');
+    expect(rowTwoColumns[6].children[0].href).toContain('/bugzillabug/1567084');
 
     // Click the dropdown button so that the menu appears
     const dropdownButton = fixture.debugElement.query(

--- a/src/app/tables/artifacts-table/artifacts-table.component.ts
+++ b/src/app/tables/artifacts-table/artifacts-table.component.ts
@@ -58,7 +58,7 @@ export class ArtifactsTableComponent implements OnChanges {
     const propValDisplayPipe = new PropertyValueDisplayPipe(this.datePipe);
     const externalUrlPipe = new NodeExternalUrlPipe();
     this.formattedArtifacts = this.artifacts.map(artifact => {
-      const formattedArtifact = {};
+      const formattedArtifact = {'See Story': 'See Story'};
       for (const [key, value] of Object.entries(artifact)) {
         // Exclude these columns since they are implementation details
         if (!['resource_type', 'display_name'].includes(key)) {
@@ -70,12 +70,14 @@ export class ArtifactsTableComponent implements OnChanges {
       // Add a link mapping in the form of:
       // {
       //   734506: {
-      //     ID: 'https://koji.domain.local/koji/buildinfo?buildID=734506'
+      //     ID: 'https://koji.domain.local/koji/buildinfo?buildID=734506',
+      //     See Story: 'https://pipeline.domain.local/kojibuild/734506'
       //   }
       //   ...
       // }
       this.linkColumnMappings[formattedArtifact[this.uidColumn]] = {
-        [this.uidColumn]: externalUrlPipe.transform(artifact)
+        [this.uidColumn]: externalUrlPipe.transform(artifact),
+        'See Story': this.getNodeStoryUrl(artifact)
       };
 
       return formattedArtifact;
@@ -120,5 +122,16 @@ export class ArtifactsTableComponent implements OnChanges {
     }
     const propDisplayPipe = new PropertyDisplayPipe();
     return columns.map(v => propDisplayPipe.transform(v));
+  }
+
+  getNodeStoryUrl(node: any) {
+    const resourceType = node.resource_type.toLowerCase();
+    let identifier;
+    if (resourceType === 'distgitcommit') {
+        identifier = node.hash;
+    } else {
+        identifier = node.id;
+    }
+    return `/${resourceType}/${identifier}`;
   }
 }

--- a/src/app/tables/table.component.html
+++ b/src/app/tables/table.component.html
@@ -16,12 +16,14 @@
           </button>
           <!-- Create a dropdown menu with all the columns the user can choose to have shown -->
           <ul *dropdownMenu class="dropdown-menu estuary-table-header__dropdown-menu">
-            <li *ngFor="let column of columns | keyvalue">
-              <!-- The default columns will be checked by default, any changes made by the user will trigger the
-                  setColumnState method to be called, which will store that state change in the columns component property.
-                  This change will then be reflected by Angular when it reruns the various ngFors in this template. -->
-              <input type="checkbox" [checked]="column.value" (change)="setColumnState(column.key)" /> {{ column.key }}
-            </li>
+            <ng-container *ngFor="let column of columns | keyvalue: sortColumns">
+              <li *ngIf="column.key !== sideColumnName">
+                <!-- The default columns will be checked by default, any changes made by the user will trigger the
+                    setColumnState method to be called, which will store that state change in the columns component property.
+                    This change will then be reflected by Angular when it reruns the various ngFors in this template. -->
+                <input type="checkbox" [checked]="column.value" (change)="setColumnState(column.key)" /> {{ column.key }}
+              </li>
+            </ng-container>
           </ul>
       </div>
 
@@ -40,12 +42,18 @@
           <thead>
             <tr>
               <!-- Display a header cell for every active column -->
-              <ng-container *ngFor="let column of columns | keyvalue">
-                <th *ngIf="column.value" (click)="sortTable(column.key)">
-                  <!-- Display an arrow if the table is being sorted by this column -->
-                  {{ column.key }}<i class="fa estuary-table__sort-icon"
-                      [ngClass]="{'fa-angle-down': sortedBy === column.key, 'fa-angle-up': sortedBy === '-' + column.key}"></i>
-                </th>
+              <ng-container *ngFor="let column of columns | keyvalue: sortColumns">
+                <ng-container *ngIf="column.key !== sideColumnName; else sideColumn">
+                  <th *ngIf="column.value" (click)="sortTable(column.key)">
+                    <!-- Display an arrow if the table is being sorted by this column -->
+                    {{ column.key }}<i class="fa estuary-table__sort-icon"
+                        [ngClass]="{'fa-angle-down': sortedBy === column.key, 'fa-angle-up': sortedBy === '-' + column.key}"></i>
+                  </th>
+                </ng-container>
+                <ng-template #sideColumn>
+                  <!-- Display an empty header above the side column -->
+                  <th></th>
+                </ng-template>
               </ng-container>
             </tr>
           </thead>
@@ -53,7 +61,7 @@
             <!-- Display a table row for every item -->
             <tr *ngFor="let item of items">
               <!-- Display all the active columns for each item -->
-              <ng-container *ngFor="let column of columns | keyvalue">
+              <ng-container *ngFor="let column of columns | keyvalue: sortColumns">
                 <!-- column.value is a boolean determining if the column is selected to be shown by the user -->
                 <td *ngIf="column.value">
                   <!-- Check if the column should be a link -->

--- a/src/app/tables/table.component.ts
+++ b/src/app/tables/table.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnChanges, Input, Output, EventEmitter } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
+import { KeyValue } from '@angular/common';
 
 
 @Component({
@@ -39,6 +40,9 @@ export class EstuaryTableComponent implements OnChanges {
   @Input() preformattedColumns: Array<string>;
   // Optional margin spacing surrounding the table
   @Input() tableSpacing = true;
+  // Name of a special column always shown on the right side of the table that cannot
+  // be deactivated. It has no header and is not included on the CSV when exported.
+  @Input() sideColumnName: string;
 
   // This will contain key value pairs, where each key is a column and each value
   // is a boolean determining if the column should be shown
@@ -78,6 +82,13 @@ export class EstuaryTableComponent implements OnChanges {
       } else {
         this.columns[column] = false;
       }
+    }
+
+    if (this.sideColumnName) {
+      this.columns[this.sideColumnName] = true;
+      // We do not want to count the side column in the count for total number of
+      // columns, so we can subtract it here.
+      this.numColumns -= 1;
     }
 
     if (this.defaultSortedColumn) {
@@ -182,5 +193,16 @@ export class EstuaryTableComponent implements OnChanges {
       tempLink.download = 'estuary.csv';
     }
     tempLink.click();
+  }
+
+  sortColumns = (colA: KeyValue<string, string>, colB: KeyValue<string, string>): number => {
+    // If the column is the side column, then we want to make sure it is last.
+    if (colA.key === this.sideColumnName) {
+      return 1;
+    } else if (colB.key === this.sideColumnName) {
+      return -1;
+    } else {
+      return (colA.key < colB.key) ? -1 : (colA.key > colB.key) ? 1 : 0;
+    }
   }
 }


### PR DESCRIPTION
Things to note:
- The way it is set up, links will by default not be included in exported CSV's, without having to do any extra code.
- The new link column will *not* count as a column, nor a selected column, at the top of the table where it says "6 of 18 columns selected". I think this makes sense since it is an extra column that will not be in the CSV, and also cannot be toggled from the drop down, but I would like to hear other opinions on that.

Looks like:
![Screenshot from 2019-10-09 11-06-14](https://user-images.githubusercontent.com/29586620/66493906-d6182500-ea84-11e9-9a11-87e6315c6f50.png)
