### PR TITLE
Provide links for waivers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bootstrap": "^3.3.7",
     "core-js": "^2.5.4",
     "jsplumb": "~2.10.0",
-    "ngx-bootstrap": "~3.3.0",
+    "ngx-bootstrap": "~5.3.2",
     "ngx-toastr": "^10.0.4",
     "patternfly": "^3.59.3",
     "rxjs": "~6.3.3",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -12,6 +12,7 @@ import { NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe, TruncateP
          NodeDisplayNamePipe } from './pipes/nodedisplay';
 import { PropertyDisplayPipe } from './pipes/propertydisplay';
 import { TimeDisplayPipe } from './pipes/timedisplay';
+import { TableColumnPipe } from './pipes/tablecolumn';
 import { StoryComponent } from './story/story.component';
 import { StoryRowComponent } from './story/storyrow/storyrow.component';
 import { StorysidebarComponent } from './story/storysidebar/storysidebar.component';
@@ -67,6 +68,7 @@ describe('AppComponent', () => {
         NodeDisplayNamePipe,
         TestResultsComponent,
         TimeDisplayPipe,
+        TableColumnPipe,
       ],
       imports: [
         AppRoutingModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { PropertyDisplayPipe, PropertyValueDisplayPipe } from './pipes/propertyd
 import { NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe,
          TruncatePipe, NodeDisplayNamePipe } from './pipes/nodedisplay';
 import { TimeDisplayPipe } from './pipes/timedisplay';
+import { TableColumnPipe } from './pipes/tablecolumn';
 import { SearchComponent } from './search/search.component';
 import { SpinnerComponent } from './spinner/spinner.component';
 import { NavbarComponent } from './navbar/navbar.component';
@@ -63,6 +64,7 @@ import { HTTPErrorHandler } from './interceptors/http-error-handler';
     TestsTableComponent,
     TestResultsComponent,
     TimeDisplayPipe,
+    TableColumnPipe,
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/pipes/tablecolumn.ts
+++ b/src/app/pipes/tablecolumn.ts
@@ -1,0 +1,13 @@
+import { PipeTransform, Pipe } from '@angular/core';
+
+@Pipe({name: 'tableColumn'})
+export class TableColumnPipe implements PipeTransform {
+  transform(uid: string, uidColumn: any, columnName: string, mapping: any): any {
+    return (
+        uidColumn
+        && mapping
+        && mapping[uid]
+        && mapping[uid][columnName]
+    );
+  }
+}

--- a/src/app/recents/recents.component.spec.ts
+++ b/src/app/recents/recents.component.spec.ts
@@ -1,6 +1,7 @@
 import { fakeAsync, ComponentFixture, TestBed, tick } from '@angular/core/testing';
 import { DatePipe } from '@angular/common';
 import { TabsModule } from 'ngx-bootstrap/tabs';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { of } from 'rxjs';
 import { NavigationEnd } from '@angular/router';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -14,6 +15,7 @@ import { RecentsComponent } from './recents.component';
 import { RecentsService } from '../services/recents.service';
 import { recents } from './test.data';
 import { NodeTypeDisplayPipe, NodeExternalUrlPipe, TruncatePipe } from '../pipes/nodedisplay';
+import { TableColumnPipe } from '../pipes/tablecolumn';
 import { ArtifactsTableComponent } from '../tables/artifacts-table/artifacts-table.component';
 import { EstuaryTableComponent } from '../tables/table.component';
 import { PropertyDisplayPipe, PropertyValueDisplayPipe } from '../pipes/propertydisplay';
@@ -33,6 +35,7 @@ describe('RecentsComponent', () => {
         PropertyDisplayPipe,
         PropertyValueDisplayPipe,
         RecentsComponent,
+        TableColumnPipe,
         TruncatePipe
       ],
       providers: [
@@ -45,6 +48,7 @@ describe('RecentsComponent', () => {
         NoopAnimationsModule,
         BsDropdownModule.forRoot(),
         ToastrModule.forRoot({}),
+        TooltipModule.forRoot(),
       ],
       // This is used to avoid having to import components we don't test here
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/story/test.data.ts
+++ b/src/app/story/test.data.ts
@@ -504,28 +504,28 @@ export const relationships = {
 
 export const greenwaveDecision: GreenwaveDecision = {
   'applicable_policies': [
-    'cvp-default'
+    'osci_compose_modules'
   ],
   'policies_satisfied': true,
   'results': [
     {
       'data': {
         'item': [
-          'cfme-openshift-app-ui-container-5.9.3.4-1.1533127933'
+          'python36-3.6-8010020190626162728.a920e634'
         ],
         'log': [
-          'https://jenkins.domain.local/job/cvp-product-test/1/console'
+          'https://jenkins.domain.local/job/ci-openstack-mbs/452/console'
         ],
       },
       'groups': [
-        'f79f00c2-e0be-4782-8613-7d1b7fa7b6d6'
+        '8a8aac63-7d57-4fdc-987a-bc47d8e036a7'
       ],
-      'href': 'https://resultsdb.domain.local/api/v2.0/results/6125427',
-      'id': 6125427,
+      'href': 'https://resultsdb.domain.local/api/v2.0/results/7504236',
+      'id': 7504236,
       'note': '',
-      'outcome': 'INFO',
+      'outcome': 'FAILED',
       'ref_url': 'https://jenkins.domain.local/job/cvp-product-test/1/',
-      'submit_time': '2018-08-01T19:07:05.442807',
+      'submit_time': '2019-06-26T16:56:01.750240',
       'testcase': {
         'href': 'https://resultsdb.domain.local/api/v2.0/testcases/rhproduct.default.functional',
         'name': 'rhproduct.default.functional',
@@ -535,21 +535,21 @@ export const greenwaveDecision: GreenwaveDecision = {
     {
       'data': {
         'item': [
-          'cfme-openshift-app-ui-container-5.9.3.4-1.1533127933'
+          'python36-3.6-8010020190626162728.a920e634'
         ],
         'log': [
-          'https://jenkins.domain.local/job/cvp-product-test/1/console'
+          'https://jenkins.domain.local/job/ci-openstack-mbs/120/console'
         ],
       },
       'groups': [
-        'b6d8bbeb-a7ea-4bc3-b062-25eb8f404b2e'
+        '7e03a6b6-6341-4826-ac35-9293bc4c851d'
       ],
-      'href': 'https://resultsdb.domain.local/api/v2.0/results/6125318',
-      'id': 6125318,
+      'href': 'https://resultsdb.domain.local/api/v2.0/results/7504231',
+      'id': 7504231,
       'note': '',
       'outcome': 'PASSED',
       'ref_url': 'https://jenkins.domain.local/job/cvp-product-test/1/',
-      'submit_time': '2018-08-01T19:03:49.074767',
+      'submit_time': '2019-06-26T16:56:01.750240',
       'testcase': {
         'href': 'https://resultsdb.domain.local/api/v2.0/testcases/rhproduct.default.sanity',
         'name': 'rhproduct.default.sanity',
@@ -559,21 +559,21 @@ export const greenwaveDecision: GreenwaveDecision = {
     {
       'data': {
         'item': [
-          'cfme-openshift-app-ui-container-5.9.3.4-1.1533127933'
+          'python36-3.6-8010020190626162728.a920e634'
         ],
         'log': [
-          'https://jenkins.domain.local/job/cvp-product-test/1/console'
+          'https://jenkins.domain.local/job/ci-openstack-mbs/2244/console'
         ],
       },
       'groups': [
-        'b6d8bbeb-a7ea-4bc3-b062-25eb8f404b2e'
+        'ab1280d8-8c6f-4272-b6e2-d9a31f42e27b'
       ],
-      'href': 'https://resultsdb.domain.local/api/v2.0/results/6125319',
-      'id': 6125319,
+      'href': 'https://resultsdb.domain.local/api/v2.0/results/7504227',
+      'id': 7504227,
       'note': '',
-      'outcome': 'PASSED',
+      'outcome': 'INFO',
       'ref_url': 'https://jenkins.domain.local/job/cvp-product-test/1/',
-      'submit_time': '2018-08-01T19:04:49.074767',
+      'submit_time': '2019-06-26T16:56:01.750240',
       'testcase': {
         'href': 'https://resultsdb.domain.local/api/v2.0/testcases/rhproduct.default.sanity',
         'name': 'rhproduct.default.sanity',
@@ -583,19 +583,28 @@ export const greenwaveDecision: GreenwaveDecision = {
   ],
   'satisfied_requirements': [
     {
-      'result_id': 6125319,
+      'result_id': 7504236,
       'testcase': 'rhproduct.default.sanity',
       'type': 'test-result-passed'
     },
     {
-      'result_id': 6125427,
+      'result_id': 7504231,
       'testcase': 'rhproduct.default.functional',
       'type': 'test-result-passed'
     }
   ],
   'summary': 'All required tests passed',
   'unsatisfied_requirements': [],
-  'waivers': []
+  'waivers': [
+    {
+      'comment': 'This is due to the dependency not being in the compose yet',
+      'id': 16549,
+      'product_version': 'rhel-8',
+      'subject_identifier': 'python36-3.6-8010020190626162728.a920e634',
+      'testcase': 'rhproduct.default.sanity',
+      'waived': true,
+    }
+  ]
 };
 
 export const containerBuild = {

--- a/src/app/tables/artifacts-table/artifacts-table.component.spec.ts
+++ b/src/app/tables/artifacts-table/artifacts-table.component.spec.ts
@@ -6,6 +6,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 
 import { ArtifactsTableComponent } from './artifacts-table.component';
@@ -13,6 +14,7 @@ import { EstuaryTableComponent } from '../table.component';
 import { TruncateModalComponent } from '../truncate-modal/truncate-modal.component';
 import { NodeExternalUrlPipe, TruncatePipe } from '../../pipes/nodedisplay';
 import { PropertyDisplayPipe, PropertyValueDisplayPipe } from '../../pipes/propertydisplay';
+import { TableColumnPipe } from '../../pipes/tablecolumn';
 import { siblings } from '../../story/test.data';
 
 
@@ -40,6 +42,7 @@ describe('ArtifactsTableComponent', () => {
         NodeExternalUrlPipe,
         PropertyDisplayPipe,
         PropertyValueDisplayPipe,
+        TableColumnPipe,
         TruncatePipe,
         TruncateModalComponent,
       ],
@@ -50,6 +53,7 @@ describe('ArtifactsTableComponent', () => {
         BsDropdownModule.forRoot(),
         ModalModule.forRoot(),
         ToastrModule.forRoot({}),
+        TooltipModule.forRoot(),
       ]
     }).compileComponents();
   });

--- a/src/app/tables/table.component.html
+++ b/src/app/tables/table.component.html
@@ -65,12 +65,11 @@
                 <!-- column.value is a boolean determining if the column is selected to be shown by the user -->
                 <td *ngIf="column.value">
                   <!-- Check if the column should be a link -->
-                  <ng-container *ngIf="linkColumnMappings &&
-                                      uidColumn &&
-                                      linkColumnMappings[item[uidColumn]] !== undefined &&
-                                      linkColumnMappings[item[uidColumn]][column.key] !== undefined;
+                  <ng-container *ngIf="item[uidColumn] | tableColumn:uidColumn:column.key:linkColumnMappings;
                                       else notLinkColumn">
-                    <a [href]="linkColumnMappings[item[uidColumn]][column.key]" target="_blank">
+                    <a [href]="linkColumnMappings[item[uidColumn]][column.key]"
+                      tooltip="{{ item[uidColumn] | tableColumn:uidColumn:column.key:tooltipColumnMappings }}"
+                      [adaptivePosition]="false" target="_blank">
                       {{ item[column.key] }}
                     </a>
                   </ng-container>
@@ -86,7 +85,10 @@
 
                     <!-- By default, just show the value the way it is -->
                     <ng-template #notTruncatedColumn>
-                      {{ item[column.key] }}
+                      <span tooltip="{{ item[uidColumn] | tableColumn:uidColumn:column.key:tooltipColumnMappings }}"
+                            [adaptivePosition]="false">
+                        {{ item[column.key] }}
+                      </span>
                     </ng-template>
                   </ng-template>
                 </td>

--- a/src/app/tables/table.component.spec.ts
+++ b/src/app/tables/table.component.spec.ts
@@ -5,10 +5,12 @@ import { By } from '@angular/platform-browser';
 import { ToastrModule } from 'ngx-toastr';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { EstuaryTableComponent } from './table.component';
 import { TruncateModalComponent } from './truncate-modal/truncate-modal.component';
 import { TruncatePipe } from '../pipes/nodedisplay';
+import { TableColumnPipe } from '../pipes/tablecolumn';
 
 
 describe('EstuaryTableComponent', () => {
@@ -45,6 +47,7 @@ describe('EstuaryTableComponent', () => {
       declarations: [
         TestHostComponent,
         EstuaryTableComponent,
+        TableColumnPipe,
         TruncateModalComponent,
         TruncatePipe,
       ],
@@ -53,6 +56,7 @@ describe('EstuaryTableComponent', () => {
         ToastrModule.forRoot({}),
         ModalModule.forRoot(),
         BsDropdownModule.forRoot(),
+        TooltipModule.forRoot(),
       ],
     })
     .compileComponents();

--- a/src/app/tables/table.component.ts
+++ b/src/app/tables/table.component.ts
@@ -35,6 +35,15 @@ export class EstuaryTableComponent implements OnChanges {
   //   ...
   // }
   @Input() linkColumnMappings: any;
+  // A mapping of the item UID to an object with the keys as column names and values
+  // as the corresponding text to show as a tooltip. For example:
+  // {
+  //   1: {
+  //     Waived: 'The test was faulty'
+  //   }
+  //   ...
+  // }
+  @Input() tooltipColumnMappings: any;
   // All columns that should be wrapped in "pre" tags when they are shown in
   // a modal when the initial value is truncated
   @Input() preformattedColumns: Array<string>;

--- a/src/app/tables/tests-table/tests-table.component.html
+++ b/src/app/tables/tests-table/tests-table.component.html
@@ -5,5 +5,6 @@
     [defaultColumns]="defaultColumns"
     [uidColumn]="uidColumn"
     [linkColumnMappings]="linkColumnMappings"
+    [tooltipColumnMappings]="tooltipColumnMappings"
     [defaultSortedColumn]="defaultSortedColumn"
 ></app-table>

--- a/src/app/tables/tests-table/tests-table.component.spec.ts
+++ b/src/app/tables/tests-table/tests-table.component.spec.ts
@@ -7,12 +7,14 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ToastrModule } from 'ngx-toastr';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { TestsTableComponent } from './tests-table.component';
 import { EstuaryTableComponent } from '../table.component';
 import { TruncateModalComponent } from '../truncate-modal/truncate-modal.component';
 import { GreenwaveDecision } from '../../models/greenwave.type';
 import { TruncatePipe } from '../../pipes/nodedisplay';
+import { TableColumnPipe } from '../../pipes/tablecolumn';
 import { greenwaveDecision as greenwaveDecisionTestData } from '../../story/test.data';
 
 
@@ -40,6 +42,7 @@ describe('ArtifactsTableComponent', () => {
         TestHostComponent,
         TestsTableComponent,
         EstuaryTableComponent,
+        TableColumnPipe,
         TruncatePipe,
         TruncateModalComponent,
       ],
@@ -49,7 +52,8 @@ describe('ArtifactsTableComponent', () => {
         ToastrModule.forRoot({}),
         NoopAnimationsModule,
         BsDropdownModule.forRoot(),
-        ModalModule.forRoot()
+        ModalModule.forRoot(),
+        TooltipModule.forRoot(),
       ]
     }).compileComponents();
   });
@@ -58,16 +62,17 @@ describe('ArtifactsTableComponent', () => {
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     component.greenwaveDecision = greenwaveDecisionTestData;
-      component.subjectIdentifier = 'cfme-openshift-app-ui-container-5.9.3.4-1.1533127933';
+      component.subjectIdentifier = 'python36-3.6-8010020190626162728.a920e634';
     fixture.detectChanges();
   });
 
   it('should show the test results from a Greenwave decision', fakeAsync(() => {
     const resultsDBURL = 'https://resultsdb.domain.local/api/v2.0/';
+    const waiverDBURL = 'https://waiverdb.domain.local/api/v1.0/';
     const jenkinsLogURL = 'https://jenkins.domain.local/job/cvp-product-test/1/';
     // Ensure the title on the page is correct
     const title = fixture.debugElement.query(By.css('.table-title')).nativeElement;
-    expect(title.textContent.trim()).toBe('Test Results for cfme-openshift-app-ui-container-5.9.3.4-1.1533127933');
+    expect(title.textContent.trim()).toBe('Test Results for python36-3.6-8010020190626162728.a920e634');
 
     // Ensure the table headers show only the default columns
     const tableHeaders = fixture.debugElement.queryAll(By.css('.estuary-table th'));
@@ -93,8 +98,8 @@ describe('ArtifactsTableComponent', () => {
 
     let idLink = rowOneColumns[0].children[0];
     expect(idLink.tagName).toBe('A');
-    expect(idLink.textContent.trim()).toBe('6125319');
-    expect(idLink.href).toBe(`${resultsDBURL}results/6125319`);
+    expect(idLink.textContent.trim()).toBe('7504231');
+    expect(idLink.href).toBe(`${resultsDBURL}results/7504231`);
 
     expect(rowOneColumns[1].textContent.trim()).toBe('Yes');
 
@@ -110,12 +115,15 @@ describe('ArtifactsTableComponent', () => {
     expect(testCaseLink.textContent.trim()).toBe('rhproduct.default.sanity');
     expect(testCaseLink.href).toBe(`${resultsDBURL}testcases/rhproduct.default.sanity`);
 
+    const waivedLink = rowOneColumns[5].children[0];
+    expect(waivedLink.textContent.trim()).toBe('Yes');
+    expect(waivedLink.href).toContain('16549');
 
     const rowTwoColumns = rows[1].nativeElement.children;
     idLink = rowTwoColumns[0].children[0];
     expect(idLink.tagName).toBe('A');
-    expect(idLink.textContent.trim()).toBe('6125427');
-    expect(idLink.href).toBe(`${resultsDBURL}results/6125427`);
+    expect(idLink.textContent.trim()).toBe('7504236');
+    expect(idLink.href).toBe(`${resultsDBURL}results/7504236`);
 
     expect(rowTwoColumns[1].textContent.trim()).toBe('Yes');
 
@@ -124,7 +132,7 @@ describe('ArtifactsTableComponent', () => {
     expect(logsLink.textContent.trim()).toBe('Test Run Logs');
     expect(logsLink.href).toBe(jenkinsLogURL);
 
-    expect(rowTwoColumns[3].textContent.trim()).toBe('INFO');
+    expect(rowTwoColumns[3].textContent.trim()).toBe('FAILED');
 
     testCaseLink = rowTwoColumns[4].children[0];
     expect(testCaseLink.tagName).toBe('A');

--- a/src/app/tables/tests-table/tests-table.component.ts
+++ b/src/app/tables/tests-table/tests-table.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { GreenwaveDecision } from '../../models/greenwave.type';
+import { environment } from '../../../environments/environment';
 
 
 @Component({
@@ -17,6 +18,7 @@ export class TestsTableComponent implements OnChanges {
   defaultSortedColumn: string;
   uidColumn: string;
   linkColumnMappings: any;
+  tooltipColumnMappings: any;
 
   constructor() {
     this.defaultColumns = ['ID', 'Logs', 'Status', 'Test Case', 'Waived', 'Impacts the Decision'];
@@ -38,6 +40,7 @@ export class TestsTableComponent implements OnChanges {
   processDecision() {
     this.formattedResults = [];
     this.linkColumnMappings = {};
+    this.tooltipColumnMappings = {};
     this.title = `Test Results for ${this.subjectIdentifier}`;
     this.titleLink = null;
     if (!this.greenwaveDecision) {
@@ -77,6 +80,16 @@ export class TestsTableComponent implements OnChanges {
         if (result.data.log) {
           formattedResult['Logs'] = 'Test Run Logs';
           this.linkColumnMappings[result.id]['Logs'] = result.ref_url;
+        }
+
+        if (result.testcase.name) {
+          for (const waiver of this.greenwaveDecision.waivers) {
+            if (waiver.testcase === result.testcase.name) {
+              const url = environment.waiverDbAPI + waiver.id;
+              this.linkColumnMappings[result.id]['Waived'] = url;
+              this.tooltipColumnMappings[result.id] = {Waived: waiver.comment};
+            }
+          }
         }
 
         this.formattedResults.push(formattedResult);

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,4 +10,5 @@ export const environment = {
   oidcIssuer: null,
   oidcClientId: null,
   greenwaveAPI: 'http://127.0.0.1:5001/api/v1.0/',
+  waiverDbAPI: 'http://127.0.0.1:5001/api/v1.0/',
 };


### PR DESCRIPTION
Right now the link to WaiverDB is just in the 'Waived' column. I am not sure if we should make a new column though, thoughts?
Edit: I am waiting until we decide on this before I make test cases, because in the test-results test right now, the example uses test results where nothing was waived, and therefore there would be no links. So I would be making a new one.