### PR TITLE
Correctly identify when the HTTP connection to the API failed

### DIFF
--- a/src/app/interceptors/http-error-handler.spec.ts
+++ b/src/app/interceptors/http-error-handler.spec.ts
@@ -50,4 +50,17 @@ describe(`AuthHttpInterceptor`, () => {
     expect(mockNotificationError).toHaveBeenCalledTimes(1);
     expect(mockNotificationError).toHaveBeenCalledWith('some error');
   });
+
+  it('should send a notification if the connection fails', () => {
+    const mockNotificationError = spyOn(notification, 'error');
+    // Start an HTTP request
+    httpClient.get(environment.api).subscribe(() => {}, () => {});
+    const req = httpTestingController.expectOne(environment.api);
+    // End the request with a connection error
+    req.flush(null, { status: 0, statusText: 'Unknown Error' });
+    // Verify that the toast notification would have been displayed
+    expect(mockNotificationError).toHaveBeenCalledTimes(1);
+    const errorMsg: string = mockNotificationError.calls.argsFor(0)[0];
+    expect(errorMsg.startsWith('The API server could not be reached.')).toBe(true);
+  });
 });

--- a/src/app/interceptors/http-error-handler.ts
+++ b/src/app/interceptors/http-error-handler.ts
@@ -40,9 +40,11 @@ export class HTTPErrorHandler implements HttpInterceptor {
    */
   displayError(error: HttpErrorResponse) {
     let errorDisplayMsg: string;
-    if (error.error instanceof ErrorEvent) {
+    if (error.error instanceof ErrorEvent || error.status === 0) {
       // Communication with the backend failed
-      errorDisplayMsg = 'The API server could not be reached. Please try again.';
+      errorDisplayMsg = 'The API server could not be reached. Please try again. ' +
+                        'If this continues, it might be due to your system not trusting ' +
+                        'the CA that signed the API\'s SSL certificate.';
     } else {
       // This means the backend returned an unsuccessful response code.
       // Since we know the backend will be returning JSON with the message key


### PR DESCRIPTION
This can happen due to the API being down or the user not trusting the CA that signed the SSL certificate used by the API.