### PR TITLE
Improve UX for advisories attached to container builds

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { NodeTypeDisplayPipe, NodeTypePluralPipe, NodeExternalUrlPipe,
          TruncatePipe, NodeDisplayNamePipe } from './pipes/nodedisplay';
 import { TimeDisplayPipe } from './pipes/timedisplay';
 import { TableColumnPipe } from './pipes/tablecolumn';
+import { LinkColumnTypePipe } from './pipes/linkcolumntype';
 import { SearchComponent } from './search/search.component';
 import { SpinnerComponent } from './spinner/spinner.component';
 import { NavbarComponent } from './navbar/navbar.component';
@@ -65,6 +66,7 @@ import { HTTPErrorHandler } from './interceptors/http-error-handler';
     TestResultsComponent,
     TimeDisplayPipe,
     TableColumnPipe,
+    LinkColumnTypePipe,
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/pipes/linkcolumntype.ts
+++ b/src/app/pipes/linkcolumntype.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'linkColumnType'
+})
+export class LinkColumnTypePipe implements PipeTransform {
+
+  transform(item: any): String {
+    if (item === undefined) {
+      return;
+    }
+
+    const dataType = typeof item;
+    // For now, all objects are classified as 'multiple', but could be changed in the future.
+    // Note that some objects may be of length 1, (and thus not technically multiple)  but
+    // they still count as 'multiple' for templating purposes
+    if (dataType === 'object') {
+      return 'multiple';
+    } else {
+      return 'single';
+    }
+  }
+
+}

--- a/src/app/pipes/propertydisplay.ts
+++ b/src/app/pipes/propertydisplay.ts
@@ -39,8 +39,11 @@ export class PropertyValueDisplayPipe implements PipeTransform {
       // is one, we can list out its names rather than just a number.
       if (value.length !== 0 && value[0].advisory_name) {
         return value.map(x => x.advisory_name).join(', ');
-      } else {
+      } else if (value.length !== 0) {
         return value.length.toString();
+      } else {
+        // If there is no value, '--' displays better than '0'.
+        return '--';
       }
     } else if (value instanceof Object) {
       // Only display objects' name or username properties

--- a/src/app/recents/recents.component.spec.ts
+++ b/src/app/recents/recents.component.spec.ts
@@ -16,6 +16,7 @@ import { RecentsService } from '../services/recents.service';
 import { recents } from './test.data';
 import { NodeTypeDisplayPipe, NodeExternalUrlPipe, TruncatePipe } from '../pipes/nodedisplay';
 import { TableColumnPipe } from '../pipes/tablecolumn';
+import { LinkColumnTypePipe } from '../pipes/linkcolumntype';
 import { ArtifactsTableComponent } from '../tables/artifacts-table/artifacts-table.component';
 import { EstuaryTableComponent } from '../tables/table.component';
 import { PropertyDisplayPipe, PropertyValueDisplayPipe } from '../pipes/propertydisplay';
@@ -30,6 +31,7 @@ describe('RecentsComponent', () => {
       declarations: [
         ArtifactsTableComponent,
         EstuaryTableComponent,
+        LinkColumnTypePipe,
         NodeTypeDisplayPipe,
         NodeExternalUrlPipe,
         PropertyDisplayPipe,

--- a/src/app/story/storysidebar/story.sidebar.component.spec.ts
+++ b/src/app/story/storysidebar/story.sidebar.component.spec.ts
@@ -81,7 +81,7 @@ describe('StorysidebarComponent testing', () => {
     expect(sidebarPropertiesEl.children[9].children[0].textContent).toBe('QA Contact');
     expect(sidebarPropertiesEl.children[9].children[1].textContent.trim()).toBe('user2');
     expect(sidebarPropertiesEl.children[10].children[0].textContent).toBe('Related By Commits');
-    expect(sidebarPropertiesEl.children[10].children[1].textContent.trim()).toBe('0');
+    expect(sidebarPropertiesEl.children[10].children[1].textContent.trim()).toBe('--');
     expect(sidebarPropertiesEl.children[11].children[0].textContent).toBe('Reporter');
     expect(sidebarPropertiesEl.children[11].children[1].textContent.trim()).toBe('user3');
     expect(sidebarPropertiesEl.children[12].children[0].textContent).toBe('Resolution');
@@ -90,7 +90,7 @@ describe('StorysidebarComponent testing', () => {
     expect(sidebarPropertiesEl.children[13].children[1].children[0].tagName).toBe('A');
     expect(sidebarPropertiesEl.children[13].children[1].textContent.trim()).toBe('1');
     expect(sidebarPropertiesEl.children[14].children[0].textContent).toBe('Reverted By Commits');
-    expect(sidebarPropertiesEl.children[14].children[1].textContent.trim()).toBe('0');
+    expect(sidebarPropertiesEl.children[14].children[1].textContent.trim()).toBe('--');
     expect(sidebarPropertiesEl.children[15].children[0].textContent).toBe('Severity');
     expect(sidebarPropertiesEl.children[15].children[1].textContent.trim()).toBe('high');
     expect(sidebarPropertiesEl.children[16].children[0].textContent).toBe('Short Description');

--- a/src/app/story/test.data.ts
+++ b/src/app/story/test.data.ts
@@ -478,6 +478,226 @@ export let siblings = {
   }
 };
 
+export let siblingsBuild = {
+  'data': [
+    {
+      'advisories': [
+        {
+          'actual_ship_date': '2018-05-08T18:32:03+00:00',
+          'advisory_name': 'RHSA-2018:1111-07',
+          'content_types': [
+            'rpm'
+          ],
+          'created_at': '2018-04-16T12:03:55+00:00',
+          'id': '33491',
+          'issue_date': '2018-05-08T17:15:15+00:00',
+          'product_name': 'Red Hat Enterprise Linux',
+          'product_short_name': 'RHEL',
+          'release_date': '2018-05-08T00:00:00+00:00',
+          'resource_type': 'Advisory',
+          'security_impact': 'Important',
+          'security_sla': '2018-04-04T00:00:00+00:00',
+          'state': 'SHIPPED_LIVE',
+          'status_time': '2018-05-09T17:35:52+00:00',
+          'synopsis': 'Important: kernel security,bug fix,and enhancement update',
+          'type': null,
+          'update_date': '2018-05-09T15:32:44+00:00',
+          'updated_at': '2018-05-09T17:35:52+00:00'
+        },
+        {
+          'actual_ship_date': '2018-05-08T18:32:03+00:00',
+          'advisory_name': 'RHSA-2018:2222-07',
+          'content_types': [
+            'rpm'
+          ],
+          'created_at': '2018-04-16T12:03:55+00:00',
+          'id': '33492',
+          'issue_date': '2018-05-08T17:15:15+00:00',
+          'product_name': 'Red Hat Enterprise Linux',
+          'product_short_name': 'RHEL',
+          'release_date': '2018-05-08T00:00:00+00:00',
+          'resource_type': 'Advisory',
+          'security_impact': 'Important',
+          'security_sla': '2018-04-04T00:00:00+00:00',
+          'state': 'SHIPPED_LIVE',
+          'status_time': '2018-05-09T17:35:52+00:00',
+          'synopsis': 'Important: kernel security,bug fix,and enhancement update',
+          'type': null,
+          'update_date': '2018-05-09T15:32:44+00:00',
+          'updated_at': '2018-05-09T17:35:52+00:00'
+        }
+      ],
+      'commit': {
+        'author_date': '2018-11-02T15:33:45Z',
+        'commit_date': '2018-11-02T15:33:45Z',
+        'display_name': 'commit #6e81871',
+        'hash': '6e8187175def9d9afb8cb3cd93916e32bf42f8bb',
+        'log_message': 'Bump for 13z3 rebuild\n\nResolves: rhbz#1641165\n',
+        'resource_type': 'DistGitCommit'
+      },
+     'completion_time': '2018-11-30T02:55:47Z',
+     'creation_time': '2018-11-30T02:55:50Z',
+     'display_name': 'openstack-13.0-67.1543534138',
+     'epoch': null,
+     'extra': {},
+     'id': '806970',
+     'module_builds': [
+
+     ],
+     'name': 'openstack-container',
+     'operator': false,
+     'original_nvr': 'openstack-13.0-67',
+     'owner': {
+        'display_name': 'freshmaker',
+        'email': 'freshmaker@redhat.com',
+        'name': null,
+        'resource_type': 'User',
+        'username': 'freshmaker'
+     },
+     'release': '67.1543534138',
+     'resource_type': 'ContainerKojiBuild',
+     'start_time': '2018-11-30T02:33:14Z',
+     'state': 1,
+     'tags': [
+        {
+           'display_name': 'RHBA-2018:3810-released',
+           'id': '56290',
+           'name': 'RHBA-2018:3810-released',
+           'resource_type': 'KojiTag'
+        },
+        {
+           'display_name': 'rhos-13.0-rhel-7-container-released',
+           'id': '11982',
+           'name': 'rhos-13.0-rhel-7-container-released',
+           'resource_type': 'KojiTag'
+        }
+     ],
+     'triggered_by_freshmaker_event': {
+        'display_name': 'Freshmaker event 3171',
+        'event_type_id': 8,
+        'id': '3171',
+        'message_id': 'ID:messaging.redhat.com-39911-1543520580542-9:9795:0:0:1.RHSA-2018:3738-02',
+        'resource_type': 'FreshmakerEvent',
+        'state': 2,
+        'state_name': 'COMPLETE',
+        'state_reason': '11 of 186 container image(s) failed to rebuild.',
+        'time_created': '2018-11-29T22:33:07Z',
+        'time_done': null
+     },
+     'version': '13.0',
+  },
+  {
+    'advisories': [
+      {
+        'actual_ship_date': '2018-05-08T18:32:03+00:00',
+        'advisory_name': 'RHSA-2018:1234-07',
+        'content_types': [
+          'rpm'
+        ],
+        'created_at': '2018-04-16T12:03:55+00:00',
+        'id': '33481',
+        'issue_date': '2018-05-08T17:15:15+00:00',
+        'product_name': 'Red Hat Enterprise Linux',
+        'product_short_name': 'RHEL',
+        'release_date': '2018-05-08T00:00:00+00:00',
+        'resource_type': 'Advisory',
+        'security_impact': 'Important',
+        'security_sla': '2018-04-04T00:00:00+00:00',
+        'state': 'SHIPPED_LIVE',
+        'status_time': '2018-05-09T17:35:52+00:00',
+        'synopsis': 'Important: kernel security,bug fix,and enhancement update',
+        'type': null,
+        'update_date': '2018-05-09T15:32:44+00:00',
+        'updated_at': '2018-05-09T17:35:52+00:00'
+      },
+      {
+        'actual_ship_date': '2018-05-08T18:32:03+00:00',
+        'advisory_name': 'RHSA-2018:1235-07',
+        'content_types': [
+          'rpm'
+        ],
+        'created_at': '2018-04-16T12:03:55+00:00',
+        'id': '33482',
+        'issue_date': '2018-05-08T17:15:15+00:00',
+        'product_name': 'Red Hat Enterprise Linux',
+        'product_short_name': 'RHEL',
+        'release_date': '2018-05-08T00:00:00+00:00',
+        'resource_type': 'Advisory',
+        'security_impact': 'Important',
+        'security_sla': '2018-04-04T00:00:00+00:00',
+        'state': 'SHIPPED_LIVE',
+        'status_time': '2018-05-09T17:35:52+00:00',
+        'synopsis': 'Important: kernel security,bug fix,and enhancement update',
+        'type': null,
+        'update_date': '2018-05-09T15:32:44+00:00',
+        'updated_at': '2018-05-09T17:35:52+00:00'
+      }
+    ],
+    'commit': {
+      'author_date': '2018-11-02T15:33:45Z',
+      'commit_date': '2018-11-02T15:33:45Z',
+      'display_name': 'commit #6e81871',
+      'hash': '6e8187175def9d9afb8cb3cd93916e32bf42f8bb',
+      'log_message': 'Bump for 13z3 rebuild\n\nResolves: rhbz#1641165\n',
+      'resource_type': 'DistGitCommit'
+    },
+   'completion_time': '2018-11-30T02:55:47Z',
+   'creation_time': '2018-11-30T02:55:50Z',
+   'display_name': 'openstack-13.0-67.1543534138',
+   'epoch': null,
+   'extra': {},
+   'id': '806971',
+   'module_builds': [
+
+   ],
+   'name': 'openstack-container',
+   'operator': false,
+   'original_nvr': 'openstack-13.0-67',
+   'owner': {
+      'display_name': 'freshmaker',
+      'email': 'freshmaker@redhat.com',
+      'name': null,
+      'resource_type': 'User',
+      'username': 'freshmaker'
+   },
+   'release': '67.1543534138',
+   'resource_type': 'ContainerKojiBuild',
+   'start_time': '2018-11-30T02:33:14Z',
+   'state': 1,
+   'tags': [
+      {
+         'display_name': 'RHBA-2018:3810-released',
+         'id': '56290',
+         'name': 'RHBA-2018:3810-released',
+         'resource_type': 'KojiTag'
+      },
+      {
+         'display_name': 'rhos-13.0-rhel-7-container-released',
+         'id': '11982',
+         'name': 'rhos-13.0-rhel-7-container-released',
+         'resource_type': 'KojiTag'
+      }
+   ],
+   'triggered_by_freshmaker_event': {
+      'display_name': 'Freshmaker event 3171',
+      'event_type_id': 8,
+      'id': '3171',
+      'message_id': 'ID:messaging.redhat.com-39911-1543520580542-9:9795:0:0:1.RHSA-2018:3738-02',
+      'resource_type': 'FreshmakerEvent',
+      'state': 2,
+      'state_name': 'COMPLETE',
+      'state_reason': '11 of 186 container image(s) failed to rebuild.',
+      'time_created': '2018-11-29T22:33:07Z',
+      'time_done': null
+   },
+   'version': '13.0',
+  }
+  ],
+  'meta': {
+    'description': 'Container builds triggered by Freshmaker event 3171'
+  }
+};
+
 export const relationships = {
   'data': [
     {

--- a/src/app/tables/artifacts-table/artifacts-table.component.spec.ts
+++ b/src/app/tables/artifacts-table/artifacts-table.component.spec.ts
@@ -15,7 +15,8 @@ import { TruncateModalComponent } from '../truncate-modal/truncate-modal.compone
 import { NodeExternalUrlPipe, TruncatePipe } from '../../pipes/nodedisplay';
 import { PropertyDisplayPipe, PropertyValueDisplayPipe } from '../../pipes/propertydisplay';
 import { TableColumnPipe } from '../../pipes/tablecolumn';
-import { siblings } from '../../story/test.data';
+import { LinkColumnTypePipe } from '../../pipes/linkcolumntype';
+import { siblings, siblingsBuild } from '../../story/test.data';
 
 
 describe('ArtifactsTableComponent', () => {
@@ -39,6 +40,7 @@ describe('ArtifactsTableComponent', () => {
         TestHostComponent,
         ArtifactsTableComponent,
         EstuaryTableComponent,
+        LinkColumnTypePipe,
         NodeExternalUrlPipe,
         PropertyDisplayPipe,
         PropertyValueDisplayPipe,
@@ -61,12 +63,13 @@ describe('ArtifactsTableComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
-    component.artifacts = siblings.data;
-    component.title = siblings.meta.description;
     fixture.detectChanges();
   });
 
   it('should show the siblings of RHBZ#1566849', fakeAsync(() => {
+    component.artifacts = siblings.data;
+    component.title = siblings.meta.description;
+    fixture.detectChanges();
     const bzUrl = 'https://bugzilla.redhat.com/show_bug.cgi?id=';
     // Ensure the title on the page is correct
     const title = fixture.debugElement.query(By.css('.table-title')).nativeElement;
@@ -152,5 +155,52 @@ describe('ArtifactsTableComponent', () => {
         const expectedChecked = expectedActiveColumns.includes(columnText);
         expect(dropdownMenu.children[i].children[0].checked).toBe(expectedChecked);
       }
+  }));
+
+  it('should show the siblings of event 3171', fakeAsync(() => {
+    component.artifacts = siblingsBuild.data;
+    component.title = siblingsBuild.meta.description;
+    fixture.detectChanges();
+    const errataUrl = 'http://errata.engineering.redhat.com/advisory/';
+    // Ensure the title on the page is correct
+    const title = fixture.debugElement.query(By.css('.table-title')).nativeElement;
+    expect(title.textContent.trim()).toBe('Container builds triggered by Freshmaker event 3171');
+
+    // Ensure the table headers show only the default columns
+    const tableHeaders = fixture.debugElement.queryAll(By.css('.estuary-table th'));
+    expect(tableHeaders.length).toBe(8);
+    const tableHeadersText = tableHeaders.map(v => v.nativeElement.textContent.trim());
+    expect(tableHeadersText[0]).toBe('Advisories');
+
+    const activeColumnsText = fixture.debugElement.query(By.css('.estuary-table-header__columns-text')).nativeElement;
+    expect(activeColumnsText.textContent.trim()).toBe('7 of 18 columns selected');
+
+    // Ensure the actual table content is correct.
+    const rows = fixture.debugElement.queryAll(By.css('.estuary-table tbody > tr'));
+    expect(rows.length).toBe(2);
+    const rowOneColumns = rows[0].nativeElement.children;
+    expect(rowOneColumns[0].textContent.trim()).toBe('RHSA-2018:1111-07  RHSA-2018:2222-07');
+    // Test that each advisory has its own correct link
+    let idLink = rowOneColumns[0].children[0];
+    expect(idLink.tagName).toBe('A');
+    expect(idLink.textContent.trim()).toBe('RHSA-2018:1111-07');
+    expect(idLink.href).toBe(`${errataUrl}33491`);
+    idLink = rowOneColumns[0].children[1];
+    expect(idLink.tagName).toBe('A');
+    expect(idLink.textContent.trim()).toBe('RHSA-2018:2222-07');
+    expect(idLink.href).toBe(`${errataUrl}33492`);
+
+    const rowTwoColumns = rows[1].nativeElement.children;
+    expect(rowTwoColumns[0].textContent.trim()).toBe('RHSA-2018:1234-07  RHSA-2018:1235-07');
+    // Test that each advisory has its own correct link
+    idLink = rowTwoColumns[0].children[0];
+    expect(idLink.tagName).toBe('A');
+    expect(idLink.textContent.trim()).toBe('RHSA-2018:1234-07');
+    expect(idLink.href).toBe(`${errataUrl}33481`);
+    idLink = rowTwoColumns[0].children[1];
+    expect(idLink.tagName).toBe('A');
+    expect(idLink.textContent.trim()).toBe('RHSA-2018:1235-07');
+    expect(idLink.href).toBe(`${errataUrl}33482`);
+
   }));
 });

--- a/src/app/tables/artifacts-table/artifacts-table.component.ts
+++ b/src/app/tables/artifacts-table/artifacts-table.component.ts
@@ -71,14 +71,24 @@ export class ArtifactsTableComponent implements OnChanges {
       // {
       //   734506: {
       //     ID: 'https://koji.domain.local/koji/buildinfo?buildID=734506',
-      //     See Story: 'https://pipeline.domain.local/kojibuild/734506'
+      //     See Story: 'https://pipeline.domain.local/kojibuild/734506',
       //   }
       //   ...
       // }
       this.linkColumnMappings[formattedArtifact[this.uidColumn]] = {
         [this.uidColumn]: externalUrlPipe.transform(artifact),
-        'See Story': this.getNodeStoryUrl(artifact)
+        'See Story': this.getNodeStoryUrl(artifact),
       };
+
+      // If there are associated advisories, we can add links to those as well.
+      if (artifact.advisories && artifact.advisories.length) {
+        const urls = {};
+        artifact.advisories.forEach(advisory => {
+          const url = externalUrlPipe.transform(advisory);
+          urls[advisory.advisory_name] = url;
+        });
+        this.linkColumnMappings[formattedArtifact[this.uidColumn]]['Advisories'] = urls;
+      }
 
       return formattedArtifact;
     });
@@ -96,7 +106,7 @@ export class ArtifactsTableComponent implements OnChanges {
       case ('kojibuild'):
       case ('containerkojibuild'):
       case ('modulekojibuild'):
-        columns = ['id', 'completion_time', 'name', 'owner', 'release', 'version'];
+        columns = ['advisories', 'id', 'completion_time', 'name', 'owner', 'release', 'version'];
         break;
       case ('containeradvisory'):
       case ('advisory'):

--- a/src/app/tables/table.component.html
+++ b/src/app/tables/table.component.html
@@ -65,32 +65,42 @@
                 <!-- column.value is a boolean determining if the column is selected to be shown by the user -->
                 <td *ngIf="column.value">
                   <!-- Check if the column should be a link -->
-                  <ng-container *ngIf="item[uidColumn] | tableColumn:uidColumn:column.key:linkColumnMappings;
-                                      else notLinkColumn">
-                    <a [href]="linkColumnMappings[item[uidColumn]][column.key]"
-                      tooltip="{{ item[uidColumn] | tableColumn:uidColumn:column.key:tooltipColumnMappings }}"
-                      [adaptivePosition]="false" target="_blank">
-                      {{ item[column.key] }}
-                    </a>
-                  </ng-container>
-
-                  <ng-template #notLinkColumn>
-                    <!-- If the value is too long, use the TruncateModal component -->
-                    <app-truncate-modal
-                        *ngIf="item[column.key].length > 50; else notTruncatedColumn"
-                        [column]="column.key"
-                        [value]="item[column.key]"
-                        [preformatted]="preformattedColumns && preformattedColumns.includes(column.key)"
-                    ></app-truncate-modal>
-
-                    <!-- By default, just show the value the way it is -->
-                    <ng-template #notTruncatedColumn>
-                      <span tooltip="{{ item[uidColumn] | tableColumn:uidColumn:column.key:tooltipColumnMappings }}"
-                            [adaptivePosition]="false">
+                  <ng-container [ngSwitch]="item[uidColumn] | tableColumn:uidColumn:column.key:linkColumnMappings | linkColumnType">
+                    <!-- If the column mapping is still an object, and thus has multiple links, we need to break it down further -->
+                    <ng-container *ngSwitchCase="'multiple'">
+                      <ng-container *ngFor="let linkItem of linkColumnMappings[item[uidColumn]][column.key] | keyvalue">
+                        <a [href]="linkItem.value" target="_blank">
+                          {{ linkItem.key }}
+                        </a>
+                      </ng-container>
+                    </ng-container>
+                    <!-- Most links will be assigned as normal, with a single link -->
+                    <ng-container *ngSwitchCase="'single'">
+                      <a [href]="linkColumnMappings[item[uidColumn]][column.key]"
+                        tooltip="{{ item[uidColumn] | tableColumn:uidColumn:column.key:tooltipColumnMappings }}"
+                        [adaptivePosition]="false" target="_blank">
                         {{ item[column.key] }}
-                      </span>
-                    </ng-template>
-                  </ng-template>
+                      </a>
+                    </ng-container>
+                    <!-- When there is no link, we can just enter the text -->
+                    <ng-container *ngSwitchDefault>
+                      <!-- If the value is too long, use the TruncateModal component -->
+                      <app-truncate-modal
+                          *ngIf="item[column.key].length > 50; else notTruncatedColumn"
+                          [column]="column.key"
+                          [value]="item[column.key]"
+                          [preformatted]="preformattedColumns && preformattedColumns.includes(column.key)"
+                      ></app-truncate-modal>
+
+                      <!-- By default, just show the value the way it is -->
+                      <ng-template #notTruncatedColumn>
+                        <span tooltip="{{ item[uidColumn] | tableColumn:uidColumn:column.key:tooltipColumnMappings }}"
+                          [adaptivePosition]="false">
+                          {{ item[column.key] }}
+                        </span>
+                      </ng-template>
+                    </ng-container>
+                  </ng-container>
                 </td>
               </ng-container>
             </tr>

--- a/src/app/tables/table.component.spec.ts
+++ b/src/app/tables/table.component.spec.ts
@@ -11,6 +11,7 @@ import { EstuaryTableComponent } from './table.component';
 import { TruncateModalComponent } from './truncate-modal/truncate-modal.component';
 import { TruncatePipe } from '../pipes/nodedisplay';
 import { TableColumnPipe } from '../pipes/tablecolumn';
+import { LinkColumnTypePipe } from '../pipes/linkcolumntype';
 
 
 describe('EstuaryTableComponent', () => {
@@ -47,6 +48,7 @@ describe('EstuaryTableComponent', () => {
       declarations: [
         TestHostComponent,
         EstuaryTableComponent,
+        LinkColumnTypePipe,
         TableColumnPipe,
         TruncateModalComponent,
         TruncatePipe,

--- a/src/app/tables/table.component.ts
+++ b/src/app/tables/table.component.ts
@@ -30,7 +30,11 @@ export class EstuaryTableComponent implements OnChanges {
   // as the corresponding link. For example:
   // {
   //   734506: {
-  //     ID: 'https://koji.domain.local/koji/buildinfo?buildID=734506'
+  //     ID: 'https://koji.domain.local/koji/buildinfo?buildID=734506',
+  //     Advisories: {
+  //         'RHSA-123': 'https://domain.local/something/123',
+  //         'RHSA-124': 'https://domain.local/something/124',
+  //     }
   //   }
   //   ...
   // }
@@ -214,4 +218,5 @@ export class EstuaryTableComponent implements OnChanges {
       return (colA.key < colB.key) ? -1 : (colA.key > colB.key) ? 1 : 0;
     }
   }
+
 }

--- a/src/app/tables/tests-table/tests-table.component.spec.ts
+++ b/src/app/tables/tests-table/tests-table.component.spec.ts
@@ -15,6 +15,7 @@ import { TruncateModalComponent } from '../truncate-modal/truncate-modal.compone
 import { GreenwaveDecision } from '../../models/greenwave.type';
 import { TruncatePipe } from '../../pipes/nodedisplay';
 import { TableColumnPipe } from '../../pipes/tablecolumn';
+import { LinkColumnTypePipe } from '../../pipes/linkcolumntype';
 import { greenwaveDecision as greenwaveDecisionTestData } from '../../story/test.data';
 
 
@@ -42,6 +43,7 @@ describe('ArtifactsTableComponent', () => {
         TestHostComponent,
         TestsTableComponent,
         EstuaryTableComponent,
+        LinkColumnTypePipe,
         TableColumnPipe,
         TruncatePipe,
         TruncateModalComponent,


### PR DESCRIPTION
I chose to have '--' instead of just an empty string or 0, because I thought it looked better than having large amounts of data looking like it is missing with the empty string. Some of the tables have many consecutive artifacts that would have 0, so it looked better to have the placeholder '--' than to have huge empty spaces. If you would prefer empty string for consistency or some other reason though please let me know!

Relates to JIRA: FACTORY-4097